### PR TITLE
feat: File Attachments, Working Directory, and Model Configuration (Epic #132)

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -113,5 +113,10 @@
       "backgroundCompactionThreshold": 0.80,
       "bufferExhaustionThreshold": 0.95
     }
+  },
+  "copilot": {
+    "provider": null,
+    "defaultReasoningEffort": "medium",
+    "defaultWorkingDirectory": null
   }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -408,6 +408,10 @@ Wraps `@github/copilot-sdk`'s `CopilotClient`. Responsibilities:
 | **Tool Dispatch** | Internal | When the SDK invokes a tool, the handler calls the `ToolDefinition.handler()` — which may proxy to an MCP sidecar or execute locally. ALWAYS_ON_TOOLS (7 tools) are guaranteed inclusion before filling remaining slots. |
 | **Retry Logic** | Internal | Automatic retries with exponential backoff for rate-limit (429) and timeout errors. Clears auth on 401. |
 | **Handler Cleanup** | Internal | Per-call event handlers (`assistant.message_delta`, `session.idle`) are unsubscribed in a `finally` block after each `chat()` call, preventing handler accumulation on reused sessions. |
+| **File Attachments** | `chat({ attachments })` | Passes `SdkAttachment[]` (file, directory, or selection references) alongside the prompt. The SDK reads file contents and provides them as context to the model. |
+| **Working Directory** | `chat({ workingDirectory })` | Sets the base path for tool operations. Per-call override, with a server-wide default in config. Passed to `createSession({ workingDirectory })`. |
+| **Reasoning Effort** | `chat({ reasoningEffort })` | Controls model reasoning depth: `"low"`, `"medium"`, `"high"`, `"xhigh"`. Higher values increase answer quality at the cost of latency. Per-call override, with a server-wide default. |
+| **BYOK Provider** | Constructor `provider` option | Connects to alternative LLM providers (OpenAI-compatible, Azure, Anthropic, Ollama). Passed to `createSession({ provider })`. Changing the provider clears all cached sessions. |
 
 ### Tool Registry (`src/mcp/tool-registry.ts`)
 
@@ -723,6 +727,8 @@ The shell executor uses a **command allowlist**. If the allowlist is empty, the 
 | `PUT` | `/api/admin/session/config` | Admin | Update `maxToolsPerRequest` at runtime (range: 1-128). Persists to `~/.openzigs/config.json`. |
 | `GET` | `/api/admin/tasks/config` | Admin | Get current task concurrency config and queue stats. |
 | `PUT` | `/api/admin/tasks/config` | Admin | Update task concurrency settings at runtime. |
+| `GET` | `/api/admin/models/config` | Admin | Get current model config (reasoningEffort, provider, workingDirectory). |
+| `PUT` | `/api/admin/models/config` | Admin | Update model config at runtime. Persists to `~/.openzigs/config.json`. |
 | `GET` | `/api/tasks` | Token | List agent tasks (filterable by status, trigger, parent). |
 | `GET` | `/api/tasks/:id` | Token | Get task details including child count. |
 | `POST` | `/api/tasks/:id/cancel` | Token | Cancel a queued or running task. |

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -873,6 +873,177 @@ Available models depend on your Copilot subscription. Common options include:
 
 ---
 
+## File Attachments
+
+When using the Web Chat, you can attach files and directories to your messages for the AI to reference during its response. Attachments are passed to the Copilot SDK alongside the prompt and provide the model with file contents or directory structure context.
+
+### Supported Attachment Types
+
+| Type | Description |
+|---|---|
+| `file` | A single file — the SDK reads its content and makes it available to the model. |
+| `directory` | A directory path — the SDK provides the directory's structure as context. |
+| `selection` | A code selection — a highlighted range within a file (with optional `startLine` / `endLine`). |
+
+### Socket.IO Interface
+
+Include a `files` array in the `chat:message` event:
+
+```javascript
+socket.emit('chat:message', {
+  content: 'Review this code for bugs',
+  files: [
+    { type: 'file', path: '/home/user/project/src/app.ts', displayName: 'app.ts' },
+    { type: 'directory', path: '/home/user/project/src' },
+    { type: 'selection', path: '/home/user/project/src/utils.ts', startLine: 10, endLine: 25 }
+  ]
+});
+```
+
+### Working Directory
+
+A **working directory** sets the base path for all tool operations (file reads, shell commands, etc.) during a conversation. You can set it per-message or as a server-wide default.
+
+**Per-message** (Socket.IO):
+
+```javascript
+socket.emit('chat:message', {
+  content: 'List all TypeScript files',
+  workingDirectory: '/home/user/my-project'
+});
+```
+
+**Server-wide default** (config):
+
+```json
+{
+  "copilot": {
+    "defaultWorkingDirectory": "/home/user/projects/main"
+  }
+}
+```
+
+Per-message values override the server default.
+
+---
+
+## Reasoning Effort
+
+Reasoning effort controls how deeply the model reasons through a problem before responding. Higher effort produces more thorough answers at the cost of latency and token usage. This setting is passed to the Copilot SDK's `reasoningEffort` parameter.
+
+| Level | Behavior |
+|---|---|
+| `low` | Quick responses, minimal reasoning. Good for simple lookups. |
+| `medium` | Balanced (default). Suitable for most tasks. |
+| `high` | Extended reasoning. Better for complex code generation, debugging, and planning. |
+| `xhigh` | Maximum reasoning. Best for difficult multi-step problems, architecture design, and thorough analysis. |
+
+### Configuration
+
+**Admin API:**
+
+```bash
+# Get current model config
+curl -H "Authorization: Bearer <token>" http://localhost:3000/api/admin/models/config
+
+# Set reasoning effort
+curl -X PUT -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"reasoningEffort": "high"}' \
+  http://localhost:3000/api/admin/models/config
+```
+
+**Config file** (`config/default.json` or `~/.openzigs/config.json`):
+
+```json
+{
+  "copilot": {
+    "defaultReasoningEffort": "high"
+  }
+}
+```
+
+Changes take effect on the next LLM request without restarting the server.
+
+---
+
+## BYOK Provider (Bring Your Own Key)
+
+OpenZigs supports connecting to alternative LLM providers via the Copilot SDK's **provider** configuration. This allows you to use your own API keys with OpenAI-compatible endpoints, Azure OpenAI, Anthropic, or Ollama.
+
+### Supported Provider Types
+
+| Provider | Description |
+|---|---|
+| `openai` | OpenAI API or any OpenAI-compatible endpoint (e.g., Together AI, Fireworks, local vLLM). |
+| `azure` | Azure OpenAI Service with optional API version. |
+| `anthropic` | Anthropic Claude API (direct access, not through Copilot). |
+| `ollama` | Local Ollama instance for running open-weight models. |
+
+### Configuration
+
+**Admin API:**
+
+```bash
+# Set an OpenAI-compatible provider
+curl -X PUT -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider": {
+      "type": "openai",
+      "baseUrl": "https://api.openai.com/v1",
+      "apiKey": "sk-..."
+    }
+  }' \
+  http://localhost:3000/api/admin/models/config
+
+# Set Ollama (local)
+curl -X PUT -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider": {
+      "type": "ollama",
+      "baseUrl": "http://localhost:11434"
+    }
+  }' \
+  http://localhost:3000/api/admin/models/config
+
+# Clear provider (revert to GitHub Copilot)
+curl -X PUT -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"provider": null}' \
+  http://localhost:3000/api/admin/models/config
+```
+
+**Config file** (`config/default.json` or `~/.openzigs/config.json`):
+
+```json
+{
+  "copilot": {
+    "provider": {
+      "type": "openai",
+      "baseUrl": "https://api.openai.com/v1",
+      "apiKey": "sk-your-key"
+    }
+  }
+}
+```
+
+### Provider Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `type` | string | Yes | Provider type: `openai`, `azure`, `anthropic`, `ollama`. |
+| `baseUrl` | string | Yes | API base URL. |
+| `apiKey` | string | No | API key (used for `openai`, `azure`, `anthropic`). |
+| `bearerToken` | string | No | Alternative to `apiKey` — passed as Bearer token. |
+| `wireApi` | string | No | OpenAI only: `"openai"` or `"anthropic"` wire format. |
+| `azure.apiVersion` | string | No | Azure only: API version string (e.g., `"2024-02-15-preview"`). |
+
+> **Note:** Changing the provider clears all cached SDK sessions. The next message will create a fresh session with the new provider.
+
+---
+
 ## Enabling and Disabling Tools
 
 Tools can be managed via the **Admin** page at `/admin` or via the REST API. Each tool can be toggled independently.
@@ -1481,6 +1652,9 @@ All configuration lives in `config/default.json`. Environment variables are inte
 | `session.infiniteSessions.bufferExhaustionThreshold` | number | `0.95` | Context usage threshold (0-1) at which forced compaction occurs to prevent failures. |
 | `tunnel.enabled` | boolean | `false` | Enable the embedded Cloudflare Tunnel. Set to `false` (default) when using the Docker sidecar pattern. |
 | `tunnel.mode` | string | `"quick"` | `"quick"` or `"named"`. Only applies when `tunnel.enabled` is `true`. |
+| `copilot.provider` | object \| null | `null` | BYOK provider config. See [BYOK Provider](#byok-provider-bring-your-own-key). |
+| `copilot.defaultReasoningEffort` | string | `"medium"` | Default reasoning effort: `"low"`, `"medium"`, `"high"`, `"xhigh"`. |
+| `copilot.defaultWorkingDirectory` | string \| null | `null` | Default working directory path for tool operations. |
 
 **Environment variables for MCP sidecars** (typically set in `docker-compose.yml`):
 

--- a/src/api/admin-models.test.ts
+++ b/src/api/admin-models.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import express from "express";
+import request from "supertest";
+import { createAdminRouter } from "./admin.js";
+import { ToolRegistry } from "../mcp/tool-registry.js";
+import type { CopilotWrapper } from "../copilot/copilot-wrapper.js";
+import type { CopilotModel, ReasoningEffort, ProviderConfig } from "../copilot/copilot-wrapper.js";
+
+class FakeCopilot implements CopilotWrapper {
+  private reasoningEffort?: ReasoningEffort;
+  private provider?: ProviderConfig;
+  private workingDirectory?: string;
+  private maxTools = 30;
+
+  async authenticate() { return { verificationUri: "", userCode: "" }; }
+  async waitForAuth(): Promise<void> {}
+  async isAuthenticated(): Promise<boolean> { return true; }
+  async *chat(): AsyncGenerator<string> { yield "hi"; }
+  async listModels(): Promise<CopilotModel[]> { return [{ id: "gpt-4.1" }]; }
+  async onToolCall(): Promise<void> {}
+  setMaxToolsPerRequest(n: number): void { this.maxTools = n; }
+  getMaxToolsPerRequest(): number { return this.maxTools; }
+  async destroySession(): Promise<void> {}
+  hasSession(): boolean { return false; }
+  async clearAllSessions(): Promise<void> {}
+
+  getReasoningEffort(): ReasoningEffort | undefined { return this.reasoningEffort; }
+  setReasoningEffort(effort: ReasoningEffort | undefined): void { this.reasoningEffort = effort; }
+  getProvider(): ProviderConfig | undefined { return this.provider; }
+  setProvider(provider: ProviderConfig | undefined): void { this.provider = provider; }
+  getWorkingDirectory(): string | undefined { return this.workingDirectory; }
+  setWorkingDirectory(dir: string | undefined): void { this.workingDirectory = dir; }
+}
+
+describe("Admin Models Config API", () => {
+  const cleanupDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(cleanupDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  });
+
+  const createApp = async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openzigs-admin-models-"));
+    cleanupDirs.push(tmpDir);
+    const configPath = path.join(tmpDir, "config.json");
+
+    // Point the admin router's config path at our temp dir
+    process.env.OPENZIGS_CONFIG_PATH = configPath;
+
+    const toolRegistry = new ToolRegistry({
+      statePath: path.join(tmpDir, "tools.json"),
+    });
+    const copilot = new FakeCopilot();
+    const router = createAdminRouter({ toolRegistry, copilot });
+
+    const app = express();
+    app.use(express.json());
+    app.use("/api/admin", router);
+
+    return { app, copilot, configPath };
+  };
+
+  it("GET /api/admin/models/config returns defaults", async () => {
+    const { app } = await createApp();
+
+    const res = await request(app).get("/api/admin/models/config");
+    expect(res.status).toBe(200);
+    expect(res.body.reasoningEffort).toBe("medium");
+    expect(res.body.provider).toBeNull();
+    expect(res.body.workingDirectory).toBeNull();
+  });
+
+  it("PUT /api/admin/models/config updates reasoning effort", async () => {
+    const { app, copilot } = await createApp();
+
+    const res = await request(app)
+      .put("/api/admin/models/config")
+      .send({ reasoningEffort: "high" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.reasoningEffort).toBe("high");
+    expect(copilot.getReasoningEffort()).toBe("high");
+  });
+
+  it("PUT /api/admin/models/config updates working directory", async () => {
+    const { app, copilot } = await createApp();
+
+    const res = await request(app)
+      .put("/api/admin/models/config")
+      .send({ workingDirectory: "/home/user/project" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.workingDirectory).toBe("/home/user/project");
+    expect(copilot.getWorkingDirectory()).toBe("/home/user/project");
+  });
+
+  it("PUT /api/admin/models/config sets provider", async () => {
+    const { app, copilot } = await createApp();
+
+    const provider = {
+      type: "openai",
+      baseUrl: "https://api.openai.com/v1",
+      apiKey: "sk-test-123",
+    };
+
+    const res = await request(app)
+      .put("/api/admin/models/config")
+      .send({ provider });
+
+    expect(res.status).toBe(200);
+    expect(res.body.provider).toEqual(provider);
+    expect(copilot.getProvider()).toEqual(provider);
+  });
+
+  it("PUT /api/admin/models/config clears provider with null", async () => {
+    const { app, copilot } = await createApp();
+
+    // Set first
+    await request(app)
+      .put("/api/admin/models/config")
+      .send({ provider: { type: "ollama", baseUrl: "http://localhost:11434" } });
+
+    expect(copilot.getProvider()).toBeDefined();
+
+    // Clear with null
+    const res = await request(app)
+      .put("/api/admin/models/config")
+      .send({ provider: null });
+
+    expect(res.status).toBe(200);
+    expect(res.body.provider).toBeNull();
+    expect(copilot.getProvider()).toBeUndefined();
+  });
+
+  it("PUT /api/admin/models/config persists to user config file", async () => {
+    const { app, configPath } = await createApp();
+
+    await request(app)
+      .put("/api/admin/models/config")
+      .send({ reasoningEffort: "xhigh", workingDirectory: "/tmp/work" });
+
+    const saved = JSON.parse(await fs.readFile(configPath, "utf-8"));
+    expect(saved.copilot.defaultReasoningEffort).toBe("xhigh");
+    expect(saved.copilot.defaultWorkingDirectory).toBe("/tmp/work");
+  });
+
+  it("PUT /api/admin/models/config rejects invalid reasoning effort", async () => {
+    const { app } = await createApp();
+
+    const res = await request(app)
+      .put("/api/admin/models/config")
+      .send({ reasoningEffort: "ultra" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("reasoningEffort");
+  });
+
+  it("PUT /api/admin/models/config rejects provider without baseUrl", async () => {
+    const { app } = await createApp();
+
+    const res = await request(app)
+      .put("/api/admin/models/config")
+      .send({ provider: { type: "openai" } });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("baseUrl");
+  });
+
+  it("PUT /api/admin/models/config rejects invalid provider type", async () => {
+    const { app } = await createApp();
+
+    const res = await request(app)
+      .put("/api/admin/models/config")
+      .send({ provider: { type: "invalid", baseUrl: "http://localhost" } });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("provider.type");
+  });
+
+  it("PUT /api/admin/models/config rejects non-string workingDirectory", async () => {
+    const { app } = await createApp();
+
+    const res = await request(app)
+      .put("/api/admin/models/config")
+      .send({ workingDirectory: 42 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("workingDirectory");
+  });
+
+  it("PUT /api/admin/models/config accepts null reasoning effort to reset", async () => {
+    const { app, copilot } = await createApp();
+
+    // Set first
+    await request(app)
+      .put("/api/admin/models/config")
+      .send({ reasoningEffort: "high" });
+
+    expect(copilot.getReasoningEffort()).toBe("high");
+
+    // Reset with null
+    const res = await request(app)
+      .put("/api/admin/models/config")
+      .send({ reasoningEffort: null });
+
+    expect(res.status).toBe(200);
+    expect(copilot.getReasoningEffort()).toBeUndefined();
+  });
+});

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -7,6 +7,7 @@ import { logger } from "../logging/logger.js";
 import { ALWAYS_ON_TOOLS } from "../mcp/constants.js";
 import type { ToolRegistry, RiskLevel } from "../mcp/tool-registry.js";
 import type { CopilotWrapper } from "../copilot/index.js";
+import type { ReasoningEffort, ProviderConfig } from "../copilot/index.js";
 import type { DockerSidecarManager } from "../mcp/docker-sidecar-manager.js";
 import type { LocalMcpServerManager } from "../mcp/local-mcp-server-manager.js";
 import type { PromptManager } from "../productivity/prompt-manager.js";
@@ -1072,6 +1073,97 @@ export const createAdminRouter = ({ toolRegistry, sidecarManager, localServerMan
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       return res.status(400).json({ error: message });
+    }
+  });
+
+  // ── Model / Copilot Configuration ──
+  router.get("/models/config", (_req, res) => {
+    const reasoningEffort = copilot?.getReasoningEffort() ?? "medium";
+    const provider = copilot?.getProvider() ?? null;
+    const workingDirectory = copilot?.getWorkingDirectory() ?? null;
+    return res.json({ reasoningEffort, provider, workingDirectory });
+  });
+
+  router.put("/models/config", async (req, res) => {
+    const body = req.body as Record<string, unknown>;
+
+    const validEfforts = new Set(["low", "medium", "high", "xhigh"]);
+
+    if (body.reasoningEffort !== undefined) {
+      if (body.reasoningEffort !== null && (typeof body.reasoningEffort !== "string" || !validEfforts.has(body.reasoningEffort))) {
+        return res.status(400).json({ error: "reasoningEffort must be 'low', 'medium', 'high', 'xhigh', or null" });
+      }
+    }
+
+    if (body.workingDirectory !== undefined) {
+      if (body.workingDirectory !== null && typeof body.workingDirectory !== "string") {
+        return res.status(400).json({ error: "workingDirectory must be a string or null" });
+      }
+    }
+
+    if (body.provider !== undefined) {
+      if (body.provider !== null) {
+        const prov = body.provider as Record<string, unknown>;
+        const validTypes = new Set(["openai", "azure", "anthropic", "ollama"]);
+        if (!prov || typeof prov !== "object" || !validTypes.has(prov.type as string)) {
+          return res.status(400).json({ error: "provider.type must be 'openai', 'azure', 'anthropic', or 'ollama'" });
+        }
+        if (typeof prov.baseUrl !== "string" || !prov.baseUrl) {
+          return res.status(400).json({ error: "provider.baseUrl is required" });
+        }
+      }
+    }
+
+    try {
+      // Apply changes in-memory
+      if (copilot) {
+        if (body.reasoningEffort !== undefined) {
+          copilot.setReasoningEffort(
+            body.reasoningEffort === null ? undefined : (body.reasoningEffort as ReasoningEffort)
+          );
+        }
+        if (body.workingDirectory !== undefined) {
+          copilot.setWorkingDirectory(
+            body.workingDirectory === null ? undefined : (body.workingDirectory as string)
+          );
+        }
+        if (body.provider !== undefined) {
+          copilot.setProvider(
+            body.provider === null ? undefined : (body.provider as ProviderConfig)
+          );
+        }
+      }
+
+      // Persist to user config
+      const configPath = defaultConfigPath();
+      const userConfig = await readUserConfig(configPath);
+      const existingCopilot = (userConfig.copilot && typeof userConfig.copilot === "object")
+        ? (userConfig.copilot as Record<string, unknown>)
+        : {};
+
+      if (body.reasoningEffort !== undefined) {
+        existingCopilot.defaultReasoningEffort = body.reasoningEffort ?? "medium";
+      }
+      if (body.workingDirectory !== undefined) {
+        existingCopilot.defaultWorkingDirectory = body.workingDirectory;
+      }
+      if (body.provider !== undefined) {
+        existingCopilot.provider = body.provider;
+      }
+
+      userConfig.copilot = existingCopilot;
+      await writeUserConfig(configPath, userConfig);
+
+      logger.info(`Model config updated: ${Object.keys(body).join(", ")}`);
+      return res.json({
+        ok: true,
+        reasoningEffort: copilot?.getReasoningEffort() ?? "medium",
+        provider: copilot?.getProvider() ?? null,
+        workingDirectory: copilot?.getWorkingDirectory() ?? null,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return res.status(500).json({ error: message });
     }
   });
 

--- a/src/api/models.test.ts
+++ b/src/api/models.test.ts
@@ -6,10 +6,13 @@ import { createServer } from "node:http";
 import express from "express";
 import { createModelsRouter } from "./models.js";
 import type { CopilotWrapper } from "../copilot/copilot-wrapper.js";
-import type { CopilotModel } from "../copilot/copilot-wrapper.js";
+import type { CopilotModel, ReasoningEffort, ProviderConfig } from "../copilot/copilot-wrapper.js";
 
 class FakeCopilot implements CopilotWrapper {
   models: CopilotModel[];
+  private reasoningEffort?: ReasoningEffort;
+  private provider?: ProviderConfig;
+  private workingDirectory?: string;
 
   constructor(models: CopilotModel[] = [{ id: "gpt-4.1" }, { id: "claude-sonnet-4" }]) {
     this.models = models;
@@ -41,6 +44,13 @@ class FakeCopilot implements CopilotWrapper {
   async destroySession(_conversationId: string): Promise<void> {}
   hasSession(_conversationId: string): boolean { return false; }
   async clearAllSessions(): Promise<void> {}
+
+  getReasoningEffort(): ReasoningEffort | undefined { return this.reasoningEffort; }
+  setReasoningEffort(effort: ReasoningEffort | undefined): void { this.reasoningEffort = effort; }
+  getProvider(): ProviderConfig | undefined { return this.provider; }
+  setProvider(provider: ProviderConfig | undefined): void { this.provider = provider; }
+  getWorkingDirectory(): string | undefined { return this.workingDirectory; }
+  setWorkingDirectory(dir: string | undefined): void { this.workingDirectory = dir; }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -1,3 +1,5 @@
+import type { SdkAttachment } from "../copilot/copilot-wrapper.js";
+
 export type ChannelType = "discord" | "telegram" | "web";
 
 export type Attachment = {
@@ -33,6 +35,10 @@ export type IncomingMessage = {
   /** Optional per-message tool allowlist (web chat only, for V2 scoping). */
   tools?: string[];
   attachments?: Attachment[];
+  /** SDK file/directory attachments for Copilot (web chat only). */
+  files?: SdkAttachment[];
+  /** Working directory context for tool operations (web chat only). */
+  workingDirectory?: string;
   timestamp: Date;
 };
 

--- a/src/channels/web-chat.ts
+++ b/src/channels/web-chat.ts
@@ -8,7 +8,7 @@ import type {
   MessageContent
 } from "./types.js";
 import type { SessionManager } from "../sessions/session-manager.js";
-import type { UserInputRequest, UserInputResponse } from "../copilot/copilot-wrapper.js";
+import type { UserInputRequest, UserInputResponse, SdkAttachment } from "../copilot/copilot-wrapper.js";
 
 export type WebChatChannelOptions = {
   io: SocketIOServer;
@@ -170,7 +170,7 @@ export class WebChatChannel implements MessageChannel {
       void this.sendSessionHistory(socket, userId).catch(() => {});
     }
 
-    socket.on("chat:message", (data: { content?: string; model?: string; tools?: string[] }) => {
+    socket.on("chat:message", (data: { content?: string; model?: string; tools?: string[]; files?: SdkAttachment[]; workingDirectory?: string }) => {
       const content = typeof data?.content === "string" ? data.content.trim() : "";
       if (!content) {
         return;
@@ -184,6 +184,8 @@ export class WebChatChannel implements MessageChannel {
         content,
         model: data.model,
         tools: Array.isArray(data.tools) ? data.tools : undefined,
+        files: Array.isArray(data.files) ? data.files : undefined,
+        workingDirectory: typeof data.workingDirectory === "string" ? data.workingDirectory : undefined,
         timestamp: new Date()
       };
       for (const handler of this.messageHandlers) {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -99,6 +99,18 @@ export type SessionConfig = {
   infiniteSessions?: InfiniteSessionConfig;
 };
 
+export type CopilotProviderConfig =
+  | { type: "openai"; baseUrl: string; apiKey?: string; bearerToken?: string; wireApi?: "openai" | "anthropic" }
+  | { type: "azure"; baseUrl: string; apiKey?: string; bearerToken?: string; azure?: { apiVersion?: string } }
+  | { type: "anthropic"; baseUrl: string; apiKey?: string; bearerToken?: string }
+  | { type: "ollama"; baseUrl: string };
+
+export type CopilotConfig = {
+  provider?: CopilotProviderConfig | null;
+  defaultReasoningEffort?: "low" | "medium" | "high" | "xhigh";
+  defaultWorkingDirectory?: string | null;
+};
+
 export type AppConfig = {
   server: {
     port: number;
@@ -113,6 +125,7 @@ export type AppConfig = {
   mcpServers?: McpServersConfig;
   tasks?: TasksConfig;
   session?: SessionConfig;
+  copilot?: CopilotConfig;
 };
 
 const rateLimitSchema = z.object({
@@ -211,6 +224,39 @@ const sessionSchema = z.object({
   infiniteSessions: infiniteSessionsSchema,
 }).optional();
 
+const providerSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("openai"),
+    baseUrl: z.string(),
+    apiKey: z.string().optional(),
+    bearerToken: z.string().optional(),
+    wireApi: z.enum(["openai", "anthropic"]).optional(),
+  }),
+  z.object({
+    type: z.literal("azure"),
+    baseUrl: z.string(),
+    apiKey: z.string().optional(),
+    bearerToken: z.string().optional(),
+    azure: z.object({ apiVersion: z.string().optional() }).optional(),
+  }),
+  z.object({
+    type: z.literal("anthropic"),
+    baseUrl: z.string(),
+    apiKey: z.string().optional(),
+    bearerToken: z.string().optional(),
+  }),
+  z.object({
+    type: z.literal("ollama"),
+    baseUrl: z.string(),
+  }),
+]);
+
+const copilotSchema = z.object({
+  provider: providerSchema.nullable().optional().default(null),
+  defaultReasoningEffort: z.enum(["low", "medium", "high", "xhigh"]).optional().default("medium"),
+  defaultWorkingDirectory: z.string().nullable().optional().default(null),
+}).optional();
+
 const appConfigSchema = z.object({
   server: z.object({
     port: z.number()
@@ -225,6 +271,7 @@ const appConfigSchema = z.object({
   mcpServers: mcpServersSchema,
   tasks: tasksSchema,
   session: sessionSchema,
+  copilot: copilotSchema,
 });
 
 export type LoadConfigOptions = {

--- a/src/copilot/copilot-wrapper.test.ts
+++ b/src/copilot/copilot-wrapper.test.ts
@@ -409,6 +409,163 @@ describe("copilot wrapper", () => {
     expect(config?.onUserInputRequest).toBeDefined();
   });
 
+  it("passes attachments to sendAndWait", async () => {
+    let capturedInput: Record<string, unknown> | null = null;
+    const session = new FakeSession();
+    const originalSend = session.sendAndWait.bind(session);
+    session.sendAndWait = async (input: Record<string, unknown>, timeout?: number) => {
+      capturedInput = input;
+      return originalSend(input as { prompt: string }, timeout);
+    };
+
+    const client = new FakeCopilotClient();
+    client.createSession = async (config) => {
+      client.lastSessionConfig = config;
+      client.sessions.push(session);
+      return session;
+    };
+
+    const wrapper = new CopilotWrapperService({ client });
+
+    const attachments = [
+      { type: "file" as const, path: "/tmp/test.ts", displayName: "test.ts" },
+      { type: "directory" as const, path: "/tmp/src" },
+    ];
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const _chunk of wrapper.chat("Review this", { attachments })) { /* drain */ }
+
+    expect(capturedInput!.attachments).toEqual(attachments);
+  });
+
+  it("omits attachments from sendAndWait when empty", async () => {
+    let capturedInput: Record<string, unknown> | null = null;
+    const session = new FakeSession();
+    const originalSend = session.sendAndWait.bind(session);
+    session.sendAndWait = async (input: Record<string, unknown>, timeout?: number) => {
+      capturedInput = input;
+      return originalSend(input as { prompt: string }, timeout);
+    };
+
+    const client = new FakeCopilotClient();
+    client.createSession = async (config) => {
+      client.lastSessionConfig = config;
+      client.sessions.push(session);
+      return session;
+    };
+
+    const wrapper = new CopilotWrapperService({ client });
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const _chunk of wrapper.chat("Hello")) { /* drain */ }
+
+    expect(capturedInput!.attachments).toBeUndefined();
+  });
+
+  it("passes workingDirectory to createSession", async () => {
+    const client = new FakeCopilotClient();
+    const wrapper = new CopilotWrapperService({ client });
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const _chunk of wrapper.chat("Hello", { workingDirectory: "/home/user/project" })) { /* drain */ }
+
+    expect((client.lastSessionConfig as Record<string, unknown>)?.workingDirectory).toBe("/home/user/project");
+  });
+
+  it("uses default workingDirectory when no per-chat override", async () => {
+    const client = new FakeCopilotClient();
+    const wrapper = new CopilotWrapperService({ client, defaultWorkingDirectory: "/default/dir" });
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const _chunk of wrapper.chat("Hello")) { /* drain */ }
+
+    expect((client.lastSessionConfig as Record<string, unknown>)?.workingDirectory).toBe("/default/dir");
+  });
+
+  it("per-chat workingDirectory overrides default", async () => {
+    const client = new FakeCopilotClient();
+    const wrapper = new CopilotWrapperService({ client, defaultWorkingDirectory: "/default/dir" });
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const _chunk of wrapper.chat("Hello", { workingDirectory: "/override/dir" })) { /* drain */ }
+
+    expect((client.lastSessionConfig as Record<string, unknown>)?.workingDirectory).toBe("/override/dir");
+  });
+
+  it("passes reasoningEffort to createSession", async () => {
+    const client = new FakeCopilotClient();
+    const wrapper = new CopilotWrapperService({ client });
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const _chunk of wrapper.chat("Hello", { reasoningEffort: "high" })) { /* drain */ }
+
+    expect((client.lastSessionConfig as Record<string, unknown>)?.reasoningEffort).toBe("high");
+  });
+
+  it("uses default reasoningEffort when no per-chat override", async () => {
+    const client = new FakeCopilotClient();
+    const wrapper = new CopilotWrapperService({ client, defaultReasoningEffort: "xhigh" });
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const _chunk of wrapper.chat("Hello")) { /* drain */ }
+
+    expect((client.lastSessionConfig as Record<string, unknown>)?.reasoningEffort).toBe("xhigh");
+  });
+
+  it("passes provider config to createSession", async () => {
+    const client = new FakeCopilotClient();
+    const provider = { type: "openai" as const, baseUrl: "https://api.openai.com/v1", apiKey: "sk-test" };
+    const wrapper = new CopilotWrapperService({ client, provider });
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const _chunk of wrapper.chat("Hello")) { /* drain */ }
+
+    expect((client.lastSessionConfig as Record<string, unknown>)?.provider).toEqual(provider);
+  });
+
+  it("setProvider clears all cached sessions", async () => {
+    const client = new FakeCopilotClient();
+    const wrapper = new CopilotWrapperService({ client });
+
+    // Create a cached session
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const _chunk of wrapper.chat("Hello", { conversationId: "conv-provider" })) { /* drain */ }
+    expect(wrapper.hasSession("conv-provider")).toBe(true);
+
+    // Change provider — should clear sessions
+    wrapper.setProvider({ type: "ollama", baseUrl: "http://localhost:11434" });
+
+    // Wait for async clearAllSessions to settle
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(wrapper.hasSession("conv-provider")).toBe(false);
+    expect(wrapper.getProvider()?.type).toBe("ollama");
+  });
+
+  it("getReasoningEffort/setReasoningEffort work correctly", () => {
+    const wrapper = new CopilotWrapperService({});
+
+    expect(wrapper.getReasoningEffort()).toBeUndefined();
+
+    wrapper.setReasoningEffort("low");
+    expect(wrapper.getReasoningEffort()).toBe("low");
+
+    wrapper.setReasoningEffort(undefined);
+    expect(wrapper.getReasoningEffort()).toBeUndefined();
+  });
+
+  it("getWorkingDirectory/setWorkingDirectory work correctly", () => {
+    const wrapper = new CopilotWrapperService({ defaultWorkingDirectory: "/initial" });
+
+    expect(wrapper.getWorkingDirectory()).toBe("/initial");
+
+    wrapper.setWorkingDirectory("/updated");
+    expect(wrapper.getWorkingDirectory()).toBe("/updated");
+
+    wrapper.setWorkingDirectory(undefined);
+    expect(wrapper.getWorkingDirectory()).toBeUndefined();
+  });
+
   it("unsubscribes event handlers after each chat call to prevent accumulation", async () => {
     const client = new FakeCopilotClient();
     const wrapper = new CopilotWrapperService({ client });

--- a/src/copilot/copilot-wrapper.ts
+++ b/src/copilot/copilot-wrapper.ts
@@ -10,6 +10,27 @@ export type DeviceAuthInfo = {
   userCode: string;
 };
 
+// ── SDK Attachment Types ──
+export type SdkAttachment = {
+  type: "file" | "directory" | "selection";
+  path: string;
+  displayName?: string;
+  languageId?: string;
+  startLine?: number;
+  endLine?: number;
+  content?: string;
+};
+
+// ── Reasoning Effort ──
+export type ReasoningEffort = "low" | "medium" | "high" | "xhigh";
+
+// ── BYOK Provider Config ──
+export type ProviderConfig =
+  | { type: "openai"; baseUrl: string; apiKey?: string; bearerToken?: string; wireApi?: "openai" | "anthropic" }
+  | { type: "azure"; baseUrl: string; apiKey?: string; bearerToken?: string; azure?: { apiVersion?: string } }
+  | { type: "anthropic"; baseUrl: string; apiKey?: string; bearerToken?: string }
+  | { type: "ollama"; baseUrl: string };
+
 type DeviceAuthResult = {
   token: string;
   refreshToken?: string;
@@ -44,6 +65,9 @@ type SessionCreateConfig = {
   hooks?: HooksConfig;
   availableTools?: string[];
   excludedTools?: string[];
+  workingDirectory?: string;
+  reasoningEffort?: ReasoningEffort;
+  provider?: ProviderConfig;
   onUserInputRequest?: (
     request: { question: string; choices?: string[]; allowFreeform?: boolean },
     context: { sessionId: string }
@@ -53,7 +77,7 @@ type SessionCreateConfig = {
 type CopilotSessionLike = {
   readonly sessionId: string;
   on: (event: string, handler: (event: { data?: { deltaContent?: string } }) => void) => (() => void);
-  sendAndWait: (input: { prompt: string }, timeout?: number) => Promise<unknown>;
+  sendAndWait: (input: { prompt: string; attachments?: SdkAttachment[] }, timeout?: number) => Promise<unknown>;
   destroy: () => Promise<void>;
 };
 
@@ -158,6 +182,12 @@ export type ChatOptions = {
   excludedTools?: string[];
   /** Handler for interactive user input requests from the SDK's ask_user tool. */
   onUserInputRequest?: UserInputHandler;
+  /** File/directory/selection attachments sent alongside the prompt. */
+  attachments?: SdkAttachment[];
+  /** Working directory for the SDK session (base path for tool operations). */
+  workingDirectory?: string;
+  /** Reasoning effort for reasoning models (low, medium, high, xhigh). */
+  reasoningEffort?: ReasoningEffort;
 };
 
 export interface CopilotWrapper {
@@ -175,6 +205,18 @@ export interface CopilotWrapper {
   hasSession(conversationId: string): boolean;
   /** Destroy all cached sessions. */
   clearAllSessions(): Promise<void>;
+  /** Get the current reasoning effort setting. */
+  getReasoningEffort(): ReasoningEffort | undefined;
+  /** Set the default reasoning effort for reasoning models. */
+  setReasoningEffort(effort: ReasoningEffort | undefined): void;
+  /** Get the current BYOK provider configuration. */
+  getProvider(): ProviderConfig | undefined;
+  /** Set the BYOK provider configuration (clears all cached sessions). */
+  setProvider(provider: ProviderConfig | undefined): void;
+  /** Get the default working directory. */
+  getWorkingDirectory(): string | undefined;
+  /** Set the default working directory. */
+  setWorkingDirectory(dir: string | undefined): void;
 }
 
 export type CopilotWrapperOptions = {
@@ -195,6 +237,12 @@ export type CopilotWrapperOptions = {
   hooks?: HooksConfig;
   /** Default handler for interactive user input requests (ask_user). */
   onUserInputRequest?: UserInputHandler;
+  /** Default reasoning effort for reasoning models. */
+  defaultReasoningEffort?: ReasoningEffort;
+  /** BYOK provider configuration (OpenAI-compatible, Azure, Anthropic, Ollama). */
+  provider?: ProviderConfig;
+  /** Default working directory for SDK sessions. */
+  defaultWorkingDirectory?: string;
 };
 
 const defaultAuthPath = () => path.join(os.homedir(), ".openzigs", "auth.json");
@@ -354,6 +402,9 @@ export class CopilotWrapperService implements CopilotWrapper {
   private infiniteSessionsConfig?: InfiniteSessionConfig;
   private hooksConfig?: HooksConfig;
   private userInputHandler?: UserInputHandler;
+  private defaultReasoningEffort?: ReasoningEffort;
+  private providerConfig?: ProviderConfig;
+  private defaultWorkingDirectory?: string;
   private sessionCache = new Map<string, CopilotSessionLike>();
   private sessionCreationPromises = new Map<string, Promise<CopilotSessionLike>>();
 
@@ -370,7 +421,10 @@ export class CopilotWrapperService implements CopilotWrapper {
     onPermissionRequest,
     infiniteSessions,
     hooks,
-    onUserInputRequest
+    onUserInputRequest,
+    defaultReasoningEffort,
+    provider,
+    defaultWorkingDirectory
   }: CopilotWrapperOptions = {}) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.client = client ?? (new CopilotClient() as any);
@@ -386,6 +440,9 @@ export class CopilotWrapperService implements CopilotWrapper {
     this.infiniteSessionsConfig = infiniteSessions;
     this.hooksConfig = hooks;
     this.userInputHandler = onUserInputRequest;
+    this.defaultReasoningEffort = defaultReasoningEffort;
+    this.providerConfig = provider;
+    this.defaultWorkingDirectory = defaultWorkingDirectory;
   }
 
   setMaxToolsPerRequest(n: number): void {
@@ -394,6 +451,32 @@ export class CopilotWrapperService implements CopilotWrapper {
 
   getMaxToolsPerRequest(): number {
     return this.maxToolsPerRequest;
+  }
+
+  getReasoningEffort(): ReasoningEffort | undefined {
+    return this.defaultReasoningEffort;
+  }
+
+  setReasoningEffort(effort: ReasoningEffort | undefined): void {
+    this.defaultReasoningEffort = effort;
+  }
+
+  getProvider(): ProviderConfig | undefined {
+    return this.providerConfig;
+  }
+
+  setProvider(provider: ProviderConfig | undefined): void {
+    this.providerConfig = provider;
+    // Provider change invalidates all cached sessions
+    void this.clearAllSessions();
+  }
+
+  getWorkingDirectory(): string | undefined {
+    return this.defaultWorkingDirectory;
+  }
+
+  setWorkingDirectory(dir: string | undefined): void {
+    this.defaultWorkingDirectory = dir;
   }
 
   async authenticate(): Promise<DeviceAuthInfo> {
@@ -490,6 +573,8 @@ export class CopilotWrapperService implements CopilotWrapper {
         availableTools: options?.availableTools,
         excludedTools: options?.excludedTools,
         onUserInputRequest: options?.onUserInputRequest,
+        workingDirectory: options?.workingDirectory,
+        reasoningEffort: options?.reasoningEffort,
       }
     );
 
@@ -509,7 +594,7 @@ export class CopilotWrapperService implements CopilotWrapper {
     });
 
     try {
-      void this.sendWithRetries(session, message).catch((error) => {
+      void this.sendWithRetries(session, message, options?.attachments).catch((error) => {
         sendError = error;
         queue.end();
       });
@@ -592,14 +677,18 @@ export class CopilotWrapperService implements CopilotWrapper {
     }
   }
 
-  private async sendWithRetries(session: CopilotSessionLike, prompt: string) {
+  private async sendWithRetries(session: CopilotSessionLike, prompt: string, attachments?: SdkAttachment[]) {
     const maxRetries = 3;
     let attempt = 0;
 
     // eslint-disable-next-line no-constant-condition
     while (true) {
       try {
-        await session.sendAndWait({ prompt }, this.sendAndWaitTimeoutMs);
+        const input: { prompt: string; attachments?: SdkAttachment[] } = { prompt };
+        if (attachments && attachments.length > 0) {
+          input.attachments = attachments;
+        }
+        await session.sendAndWait(input, this.sendAndWaitTimeoutMs);
         return;
       } catch (error) {
         if (isUnauthorizedError(error)) {
@@ -651,10 +740,14 @@ export class CopilotWrapperService implements CopilotWrapper {
       availableTools?: string[];
       excludedTools?: string[];
       onUserInputRequest?: UserInputHandler;
+      workingDirectory?: string;
+      reasoningEffort?: ReasoningEffort;
     }
   ): SessionCreateConfig {
     const effectiveHooks = this.hooksConfig;
     const effectiveUserInput = extra?.onUserInputRequest ?? this.userInputHandler;
+    const effectiveWorkingDirectory = extra?.workingDirectory ?? this.defaultWorkingDirectory;
+    const effectiveReasoningEffort = extra?.reasoningEffort ?? this.defaultReasoningEffort;
 
     return {
       ...(sessionId ? { sessionId } : {}),
@@ -663,6 +756,9 @@ export class CopilotWrapperService implements CopilotWrapper {
       tools,
       ...(this.infiniteSessionsConfig ? { infiniteSessions: this.infiniteSessionsConfig } : {}),
       ...(extra?.systemMessage ? { systemMessage: extra.systemMessage } : {}),
+      ...(effectiveWorkingDirectory ? { workingDirectory: effectiveWorkingDirectory } : {}),
+      ...(effectiveReasoningEffort ? { reasoningEffort: effectiveReasoningEffort } : {}),
+      ...(this.providerConfig ? { provider: this.providerConfig } : {}),
       ...(effectiveHooks ? {
         hooks: {
           ...effectiveHooks,
@@ -708,6 +804,8 @@ export class CopilotWrapperService implements CopilotWrapper {
       availableTools?: string[];
       excludedTools?: string[];
       onUserInputRequest?: UserInputHandler;
+      workingDirectory?: string;
+      reasoningEffort?: ReasoningEffort;
     }
   ): Promise<CopilotSessionLike> {
     if (!conversationId) {

--- a/src/copilot/index.ts
+++ b/src/copilot/index.ts
@@ -1,2 +1,2 @@
 export { CopilotWrapperService } from "./copilot-wrapper.js";
-export type { ChatOptions, CopilotModel, CopilotWrapper, CopilotWrapperOptions, DeviceAuthInfo, InfiniteSessionConfig } from "./copilot-wrapper.js";
+export type { ChatOptions, CopilotModel, CopilotWrapper, CopilotWrapperOptions, DeviceAuthInfo, InfiniteSessionConfig, SdkAttachment, ReasoningEffort, ProviderConfig } from "./copilot-wrapper.js";

--- a/src/mcp/orchestrate-agents.test.ts
+++ b/src/mcp/orchestrate-agents.test.ts
@@ -29,6 +29,12 @@ const createMockCopilot = (responseChunks: string[] = ["result"]) => ({
   destroySession: vi.fn().mockResolvedValue(undefined),
   hasSession: vi.fn().mockReturnValue(false),
   clearAllSessions: vi.fn().mockResolvedValue(undefined),
+  getReasoningEffort: vi.fn().mockReturnValue(undefined),
+  setReasoningEffort: vi.fn(),
+  getProvider: vi.fn().mockReturnValue(undefined),
+  setProvider: vi.fn(),
+  getWorkingDirectory: vi.fn().mockReturnValue(undefined),
+  setWorkingDirectory: vi.fn(),
   chat: vi.fn().mockImplementation(async function* () {
     for (const chunk of responseChunks) {
       yield chunk;

--- a/src/routing/message-router.test.ts
+++ b/src/routing/message-router.test.ts
@@ -137,6 +137,13 @@ class FakeCopilot implements CopilotWrapper {
   async clearAllSessions(): Promise<void> {
     return undefined;
   }
+
+  getReasoningEffort() { return undefined; }
+  setReasoningEffort() {}
+  getProvider() { return undefined; }
+  setProvider() {}
+  getWorkingDirectory() { return undefined; }
+  setWorkingDirectory() {}
 }
 
 const baseMessage = (overrides: Partial<IncomingMessage> = {}): IncomingMessage => {

--- a/src/routing/message-router.ts
+++ b/src/routing/message-router.ts
@@ -1,7 +1,7 @@
 import type { ChannelManager } from "../channels/channel-manager.js";
 import type { IncomingMessage, MessageContent } from "../channels/types.js";
 import type { CopilotWrapper } from "../copilot/copilot-wrapper.js";
-import type { SystemMessageConfig, UserInputHandler } from "../copilot/copilot-wrapper.js";
+import type { SystemMessageConfig, UserInputHandler, SdkAttachment, ReasoningEffort } from "../copilot/copilot-wrapper.js";
 import type { AccessControlConfig } from "../config/index.js";
 import type { SessionManager } from "../sessions/session-manager.js";
 import type { PersonalityManager } from "../personality/personality-manager.js";
@@ -19,6 +19,12 @@ export type RouteOptions = {
   onToolCall?: (tool: string, args: unknown) => void;
   /** Optional tool allowlist for this request. Only these tools (+ ALWAYS_ON_TOOLS) will be available. */
   allowedTools?: string[];
+  /** File/directory/selection attachments to include with this message. */
+  attachments?: SdkAttachment[];
+  /** Working directory context for this message's SDK session. */
+  workingDirectory?: string;
+  /** Reasoning effort override for this message. */
+  reasoningEffort?: ReasoningEffort;
 };
 
 export type MessageRouterOptions = {
@@ -161,6 +167,9 @@ export class MessageRouter {
         systemMessage,
         availableTools,
         onUserInputRequest: this.userInputHandler,
+        attachments: options?.attachments,
+        workingDirectory: options?.workingDirectory,
+        reasoningEffort: options?.reasoningEffort,
       })) {
         response += chunk;
         if (options?.onChunk) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -169,6 +169,9 @@ const copilot = new CopilotWrapperService({
   maxToolsPerRequest: config.session?.maxToolsPerRequest ?? 30,
   infiniteSessions: config.session?.infiniteSessions,
   hooks: createHooksConfig({ toolRegistry, approvalQueue, auditLogger, sessionManager }),
+  defaultReasoningEffort: config.copilot?.defaultReasoningEffort ?? undefined,
+  provider: config.copilot?.provider ?? undefined,
+  defaultWorkingDirectory: config.copilot?.defaultWorkingDirectory ?? undefined,
 });
 
 registerMcpTools(toolRegistry, {
@@ -510,7 +513,9 @@ if (webConfig?.enabled !== false) {
           void webChatChannel.sendToolProgress(message.chatId, tool);
         },
         model: message.model, // Model is picked per-request via the UI; already read from user config by the model selector
-        allowedTools: message.tools
+        allowedTools: message.tools,
+        attachments: message.files,
+        workingDirectory: message.workingDirectory,
       })
       .then(() => {
         void webChatChannel.sendStreamEnd(message.chatId, messageId);

--- a/src/tasks/task-worker-concurrency.test.ts
+++ b/src/tasks/task-worker-concurrency.test.ts
@@ -28,6 +28,12 @@ const createMockCopilot = () => ({
   destroySession: vi.fn().mockResolvedValue(undefined),
   hasSession: vi.fn().mockReturnValue(false),
   clearAllSessions: vi.fn().mockResolvedValue(undefined),
+  getReasoningEffort: vi.fn().mockReturnValue(undefined),
+  setReasoningEffort: vi.fn(),
+  getProvider: vi.fn().mockReturnValue(undefined),
+  setProvider: vi.fn(),
+  getWorkingDirectory: vi.fn().mockReturnValue(undefined),
+  setWorkingDirectory: vi.fn(),
   chat: vi.fn().mockImplementation(async function* () {
     yield "ok";
   }),

--- a/src/tasks/task-worker.test.ts
+++ b/src/tasks/task-worker.test.ts
@@ -51,6 +51,12 @@ describe("TaskWorker", () => {
       destroySession: vi.fn().mockResolvedValue(undefined),
       hasSession: vi.fn().mockReturnValue(false),
       clearAllSessions: vi.fn().mockResolvedValue(undefined),
+      getReasoningEffort: vi.fn().mockReturnValue(undefined),
+      setReasoningEffort: vi.fn(),
+      getProvider: vi.fn().mockReturnValue(undefined),
+      setProvider: vi.fn(),
+      getWorkingDirectory: vi.fn().mockReturnValue(undefined),
+      setWorkingDirectory: vi.fn(),
       chat: vi.fn().mockImplementation(async function* () {
         for (const chunk of chunks) {
           yield chunk;
@@ -99,6 +105,12 @@ describe("TaskWorker", () => {
       destroySession: vi.fn().mockResolvedValue(undefined),
       hasSession: vi.fn().mockReturnValue(false),
       clearAllSessions: vi.fn().mockResolvedValue(undefined),
+      getReasoningEffort: vi.fn().mockReturnValue(undefined),
+      setReasoningEffort: vi.fn(),
+      getProvider: vi.fn().mockReturnValue(undefined),
+      setProvider: vi.fn(),
+      getWorkingDirectory: vi.fn().mockReturnValue(undefined),
+      setWorkingDirectory: vi.fn(),
       chat: vi.fn().mockImplementation(async function* () {
         yield ""; // eslint requires yield in generators
         throw new Error("LLM exploded");
@@ -145,6 +157,12 @@ describe("TaskWorker", () => {
       destroySession: vi.fn().mockResolvedValue(undefined),
       hasSession: vi.fn().mockReturnValue(false),
       clearAllSessions: vi.fn().mockResolvedValue(undefined),
+      getReasoningEffort: vi.fn().mockReturnValue(undefined),
+      setReasoningEffort: vi.fn(),
+      getProvider: vi.fn().mockReturnValue(undefined),
+      setProvider: vi.fn(),
+      getWorkingDirectory: vi.fn().mockReturnValue(undefined),
+      setWorkingDirectory: vi.fn(),
       chat: vi.fn().mockImplementation(async function* () {
         concurrent++;
         concurrentPeak = Math.max(concurrentPeak, concurrent);
@@ -194,6 +212,12 @@ describe("TaskWorker", () => {
       destroySession: vi.fn().mockResolvedValue(undefined),
       hasSession: vi.fn().mockReturnValue(false),
       clearAllSessions: vi.fn().mockResolvedValue(undefined),
+      getReasoningEffort: vi.fn().mockReturnValue(undefined),
+      setReasoningEffort: vi.fn(),
+      getProvider: vi.fn().mockReturnValue(undefined),
+      setProvider: vi.fn(),
+      getWorkingDirectory: vi.fn().mockReturnValue(undefined),
+      setWorkingDirectory: vi.fn(),
       chat: vi.fn().mockImplementation(async function* () {
         yield "ok";
       }),
@@ -235,6 +259,12 @@ describe("TaskWorker", () => {
       destroySession: vi.fn().mockResolvedValue(undefined),
       hasSession: vi.fn().mockReturnValue(false),
       clearAllSessions: vi.fn().mockResolvedValue(undefined),
+      getReasoningEffort: vi.fn().mockReturnValue(undefined),
+      setReasoningEffort: vi.fn(),
+      getProvider: vi.fn().mockReturnValue(undefined),
+      setProvider: vi.fn(),
+      getWorkingDirectory: vi.fn().mockReturnValue(undefined),
+      setWorkingDirectory: vi.fn(),
       chat: vi.fn().mockImplementation(async function* () {
         yield "ok";
       }),
@@ -279,6 +309,12 @@ describe("TaskWorker", () => {
       destroySession: vi.fn().mockResolvedValue(undefined),
       hasSession: vi.fn().mockReturnValue(false),
       clearAllSessions: vi.fn().mockResolvedValue(undefined),
+      getReasoningEffort: vi.fn().mockReturnValue(undefined),
+      setReasoningEffort: vi.fn(),
+      getProvider: vi.fn().mockReturnValue(undefined),
+      setProvider: vi.fn(),
+      getWorkingDirectory: vi.fn().mockReturnValue(undefined),
+      setWorkingDirectory: vi.fn(),
       chat: vi.fn().mockImplementation(async function* (_prompt: string, options?: { onToolCall?: (t: string, a: unknown) => void }) {
         capturedOnToolCall = options?.onToolCall;
         yield "done";
@@ -332,6 +368,12 @@ describe("TaskWorker", () => {
       destroySession: vi.fn().mockResolvedValue(undefined),
       hasSession: vi.fn().mockReturnValue(false),
       clearAllSessions: vi.fn().mockResolvedValue(undefined),
+      getReasoningEffort: vi.fn().mockReturnValue(undefined),
+      setReasoningEffort: vi.fn(),
+      getProvider: vi.fn().mockReturnValue(undefined),
+      setProvider: vi.fn(),
+      getWorkingDirectory: vi.fn().mockReturnValue(undefined),
+      setWorkingDirectory: vi.fn(),
       chat: vi.fn().mockImplementation(async function* () { yield "x"; }),
     };
 
@@ -359,6 +401,12 @@ describe("TaskWorker", () => {
       destroySession: vi.fn().mockResolvedValue(undefined),
       hasSession: vi.fn().mockReturnValue(false),
       clearAllSessions: vi.fn().mockResolvedValue(undefined),
+      getReasoningEffort: vi.fn().mockReturnValue(undefined),
+      setReasoningEffort: vi.fn(),
+      getProvider: vi.fn().mockReturnValue(undefined),
+      setProvider: vi.fn(),
+      getWorkingDirectory: vi.fn().mockReturnValue(undefined),
+      setWorkingDirectory: vi.fn(),
       chat: vi.fn().mockImplementation(async function* () {
         yield "done";
       }),
@@ -412,6 +460,12 @@ describe("TaskWorker", () => {
       destroySession: vi.fn().mockResolvedValue(undefined),
       hasSession: vi.fn().mockReturnValue(false),
       clearAllSessions: vi.fn().mockResolvedValue(undefined),
+      getReasoningEffort: vi.fn().mockReturnValue(undefined),
+      setReasoningEffort: vi.fn(),
+      getProvider: vi.fn().mockReturnValue(undefined),
+      setProvider: vi.fn(),
+      getWorkingDirectory: vi.fn().mockReturnValue(undefined),
+      setWorkingDirectory: vi.fn(),
       chat: vi.fn().mockImplementation(async function* () {
         yield "done";
       }),


### PR DESCRIPTION
## Summary

Implements **Epic #132** — Advanced Capabilities: Files & Models.

### Issue #133: File Attachments & Working Directory

- **`SdkAttachment` type** — Supports `file`, `directory`, and `selection` attachment types with optional `displayName`, `languageId`, `startLine`/`endLine`, and `content` fields.
- **Web Chat integration** — The `chat:message` Socket.IO event now accepts a `files` array and `workingDirectory` string, which are threaded through `IncomingMessage` → `MessageRouter` → `CopilotWrapper.chat()` → SDK `sendAndWait()`.
- **Working directory** — Configurable per-message or as a server-wide default (`copilot.defaultWorkingDirectory`). Per-message values override the default.

### Issue #134: Model Configuration — Reasoning Effort & BYOK Provider

- **Reasoning effort** — `"low"` / `"medium"` / `"high"` / `"xhigh"` controls model reasoning depth. Configurable per-message, via Admin API, or as a server default (`copilot.defaultReasoningEffort`).
- **BYOK Provider** — Connect to alternative LLM providers: OpenAI-compatible, Azure OpenAI, Anthropic, or Ollama. Provider config is validated and persisted. Changing provider clears all cached SDK sessions.
- **Admin API** — `GET /api/admin/models/config` returns current config; `PUT /api/admin/models/config` validates and applies changes in-memory + persists to `~/.openzigs/config.json`.

### Files Changed

| File | Change |
|---|---|
| `src/copilot/copilot-wrapper.ts` | Core types, interface methods, session config, attachments forwarding |
| `src/copilot/index.ts` | Barrel exports for new types |
| `src/routing/message-router.ts` | Thread attachments/workingDirectory/reasoningEffort through route pipeline |
| `src/channels/types.ts` | Extended `IncomingMessage` with `files` and `workingDirectory` |
| `src/channels/web-chat.ts` | Parse `files`/`workingDirectory` from Socket.IO payload |
| `src/server.ts` | Wire new config to `CopilotWrapperService` constructor and route options |
| `src/config/index.ts` | `CopilotConfig` type + Zod schemas for provider/reasoning/workDir |
| `config/default.json` | Default `copilot` section |
| `src/api/admin.ts` | `GET/PUT /api/admin/models/config` endpoints |
| `src/api/admin-models.test.ts` | 11 tests for admin model config API |
| `src/copilot/copilot-wrapper.test.ts` | 11 new tests for attachments, workDir, reasoning, provider |
| `docs/USER_GUIDE.md` | Sections: File Attachments, Working Directory, Reasoning Effort, BYOK Provider |
| `docs/ARCHITECTURE.md` | Updated Copilot Wrapper capability table + API Surface table |

### Quality

- ✅ `pnpm typecheck` — 0 errors
- ✅ `pnpm test` — 438 tests pass (49 files)
- ✅ `eslint` — 0 warnings/errors

Closes #133, closes #134, closes #132