### PR TITLE
feat(#413-417): global opt-in Telegram notifications for async jobs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2588,6 +2588,7 @@ flowchart TB
 | `TaskWorker` | `src/tasks/task-worker.ts` | Background polling loop, dequeues tasks, calls `CopilotWrapper.chat()` |
 | `spawn_agent` tool | `src/mcp/tools/agent-tools.ts` | MCP tool the LLM calls to create child tasks |
 | `NotificationDispatcher` | `src/tasks/notification-dispatcher.ts` | Routes completion alerts to the originating channel |
+| `MediaNotificationService` | `src/queue/media-notification-service.ts` | Opt-in Telegram notifications for media queue jobs and video renders |
 | Task API | `src/api/tasks.ts` | REST endpoints: list, get, cancel, stats |
 
 ### Execution Scenarios
@@ -4368,6 +4369,28 @@ Push-based orchestrator that polls pending jobs on a configurable tick interval 
 **Stale result recovery:** `pollForStaleResults()` runs every tick and checks dispatched jobs older than 3 minutes. For each stale job, it polls the worker's `/job-result/<id>` endpoint. If the result is available, it's processed as if the callback had arrived — this recovers jobs where the callback POST failed.
 
 **Events:** `job:dispatched`, `job:complete`, `job:failed`, `job:progress`, `project:complete`
+
+### Media Notification Service (`src/queue/media-notification-service.ts`)
+
+Instanced once at server start; wires event listeners onto `QueueMaster` and `RenderOrchestrator` to deliver opt-in Telegram push notifications for long-running async operations.
+
+**Covered surfaces:**
+- `QueueMaster` `job:complete` / `job:failed` — image/video/music generation jobs
+- `RenderOrchestrator` `render:complete` / `render:failed` — Director video renders
+- Character training — polled via `pollTrainingStatus()` → `sendTrainingTelegramNotification()`
+
+**Opt-in fields (per-job):**
+
+| Field | Type | Description |
+|---|---|---|
+| `notifyViaTelegram` | boolean | Whether to send a Telegram message on completion/failure |
+| `telegramChatId` | string \| null | Target chat; falls back to `config.channels.telegram.adminUserId` |
+
+**Flow:**
+1. Client sets `notify_via_telegram: true` in the job creation request (UI toggle or agent tool call)
+2. The flag is persisted in the `media_jobs` SQLite row (`notify_via_telegram INTEGER`, `telegram_chat_id TEXT`)
+3. On the terminal event, `MediaNotificationService` checks the flag, resolves the chat ID, then calls `ChannelManager.getChannel("telegram").sendMessage()`
+4. Gracefully degrades if Telegram is not configured or not connected — no crash, warn-level log
 
 ### Media Queue Repository (`src/queue/media-queue-repository.ts`)
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -5641,6 +5641,37 @@ Internal filesystem paths are stripped from error responses. 500 errors return a
 
 ---
 
+## Telegram Notifications for Async Jobs
+
+Long-running jobs — image/video/music generation, video renders, and LoRA character training — can send you a Telegram message when they finish or fail, even if you've closed the browser tab.
+
+### How to Enable
+
+Toggle the **Notify via Telegram** switch (paper-plane icon) that appears near the submit button for each supported surface:
+
+| Surface | Location |
+|---|---|
+| Gallery Studio / Media generation | In the generation form, next to the submit button |
+| Music Studio — Smart Remix Lab | Below the Analyze button |
+| Director Mode — Review & Produce | Between the vision analysis toggle and the render quality settings |
+| Characters — LoRA Training | Next to the Start Training button |
+
+The toggle is off by default. Enable it for individual jobs as needed.
+
+### Requirements
+
+1. A Telegram bot must be configured: `TELEGRAM_BOT_TOKEN` environment variable (or `channels.telegram.botToken` in `~/.openzigs/config.json`).
+2. The bot must have sent at least one message to the target chat, or `channels.telegram.adminUserId` must be set as the fallback destination.
+
+### Agentic Use
+
+When asking the AI agent to generate media, you can request a notification:
+> "Create a 4-second video of a sunset and send me a Telegram when it's done."
+
+The agent will automatically set `notify_via_telegram: true` on the job (see the Media Director and Remix Engineer skill guides).
+
+---
+
 ## Media Queue & Asset Gallery
 
 The Media Queue is a push-based distributed job system for generating images, videos, and music across networked GPU nodes. Jobs are dispatched to workers asynchronously — the worker accepts the job immediately (HTTP 202) and POSTs a completion callback back to the primary Mac when done. The Asset Gallery provides a visual interface for browsing, filtering, and managing all generated and uploaded media.

--- a/src/api/characters.ts
+++ b/src/api/characters.ts
@@ -13,6 +13,7 @@ import type { CharacterRepository, CharacterCreate, CharacterUpdate } from "../c
 import type { CopilotWrapperService, SdkAttachment } from "../copilot/copilot-wrapper.js";
 import type { Server as SocketIOServer } from "socket.io";
 import { getUserSelectedModel } from "../config/user-model.js";
+import type { ChannelManager } from "../channels/channel-manager.js";
 
 // ── Types ───────────────────────────────────────────────────
 
@@ -25,6 +26,14 @@ export interface CharacterRouterDeps {
 let _io: SocketIOServer | null = null;
 export function setCharacterIO(io: SocketIOServer): void {
   _io = io;
+}
+
+// ── Channel manager (injected for Telegram training notifications) ─
+let _channelManager: ChannelManager | null = null;
+let _fallbackChatId: string | undefined;
+export function setCharacterChannelManager(mgr: ChannelManager, fallbackChatId?: string): void {
+  _channelManager = mgr;
+  _fallbackChatId = fallbackChatId;
 }
 
 // ── In-flight training cancellation flags ────────────────────
@@ -355,6 +364,8 @@ export function createCharacterRouter({ characterRepo, copilot }: CharacterRoute
       const learningRate = typeof overrides.learningRate === "number" ? overrides.learningRate : 1e-4;
       const loraRank = typeof overrides.loraRank === "number" ? overrides.loraRank : 16;
       const numEpochs = typeof overrides.numEpochs === "number" ? overrides.numEpochs : 50;
+      const notifyViaTelegram = overrides.notifyViaTelegram === true;
+      const telegramChatId = typeof overrides.telegramChatId === "string" ? overrides.telegramChatId : undefined;
 
       // Build per-image prompt: use per-image caption if available,
       // fall back to character description, then generic trigger-word prompt
@@ -402,7 +413,7 @@ export function createCharacterRouter({ characterRepo, copilot }: CharacterRoute
       });
 
       // POST to the image-gen sidecar's /train endpoint
-      startRemoteTraining(character.id, sidecarUrl, trainConfig, photos, characterRepo);
+      startRemoteTraining(character.id, sidecarUrl, trainConfig, photos, characterRepo, notifyViaTelegram, telegramChatId);
 
       logger.info(`[Characters] Started LoRA training for '${character.name}' (${character.id}) via ${sidecarUrl}`);
       res.json({
@@ -859,6 +870,24 @@ async function getImageGenToken(): Promise<string> {
   return "";
 }
 
+// ── Telegram notification helper for training events ──────────────────────
+function sendTrainingTelegramNotification(
+  characterId: string,
+  characterName: string,
+  outcome: "complete" | "failed",
+  chatId: string,
+  message?: string,
+): void {
+  const telegram = _channelManager?.getChannel("telegram");
+  if (!telegram || !telegram.isConnected()) return;
+  const text = outcome === "complete"
+    ? `✅ *LoRA training complete* for character *${characterName}*. Ready to use!`
+    : `❌ *LoRA training failed* for character *${characterName}*${message ? `\n${message}` : ""}. Please check the logs.`;
+  telegram.sendMessage(chatId, { text, markdown: true }).catch((err: unknown) => {
+    logger.warn(`[Characters] Failed to send training Telegram notification for ${characterId}: ${err instanceof Error ? err.message : String(err)}`);
+  });
+}
+
 // ── Remote Training Manager ─────────────────────────────────
 
 async function startRemoteTraining(
@@ -867,6 +896,8 @@ async function startRemoteTraining(
   trainConfig: Record<string, unknown>,
   photos: Array<{ image_base64: string; filename: string; prompt: string }>,
   characterRepo: CharacterRepository,
+  notifyViaTelegram = false,
+  telegramChatId?: string,
 ): Promise<void> {
   const token = await getImageGenToken();
 
@@ -900,7 +931,7 @@ async function startRemoteTraining(
     _io?.emit("character:training:start", { characterId, characterName });
 
     // Start polling for completion
-    pollTrainingStatus(characterId, characterName, sidecarUrl, token, result.output_dir ?? null, characterRepo);
+    pollTrainingStatus(characterId, characterName, sidecarUrl, token, result.output_dir ?? null, characterRepo, notifyViaTelegram, telegramChatId);
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     characterRepo.update(characterId, {
@@ -935,6 +966,8 @@ function pollTrainingStatus(
   token: string,
   _outputDir: string | null,
   characterRepo: CharacterRepository,
+  notifyViaTelegram = false,
+  telegramChatId?: string,
 ): void {
   const pollIntervalMs = 15_000; // 15 seconds
   const startTime = Date.now();
@@ -969,6 +1002,10 @@ function pollTrainingStatus(
               errorMessage: `Training timed out after ${hours}h but a partial checkpoint was saved and is usable. Results may improve with more training.`,
             });
             _io?.emit("character:training:complete", { characterId, characterName, partial: true });
+            if (notifyViaTelegram) {
+              const chatId = telegramChatId ?? _fallbackChatId;
+              if (chatId) sendTrainingTelegramNotification(characterId, characterName, "complete", chatId);
+            }
             logger.warn(`[Characters] Training timed out for ${characterId} but partial checkpoint is usable: ${status.lora_path}`);
             return;
           }
@@ -981,6 +1018,10 @@ function pollTrainingStatus(
         errorMessage: `Training timed out after ${hours} hours. The sidecar may still be training — check its logs. You can increase the timeout in config (imageGen.trainingTimeoutHours).`,
       });
       _io?.emit("character:training:failed", { characterId, characterName });
+      if (notifyViaTelegram) {
+        const chatId = telegramChatId ?? _fallbackChatId;
+        if (chatId) sendTrainingTelegramNotification(characterId, characterName, "failed", chatId, `Timed out after ${hours}h`);
+      }
       logger.error(`[Characters] Training timed out for ${characterId}`);
       return;
     }
@@ -1016,6 +1057,10 @@ function pollTrainingStatus(
           errorMessage: status.error,
         });
         _io?.emit("character:training:failed", { characterId, characterName });
+        if (notifyViaTelegram) {
+          const chatId = telegramChatId ?? _fallbackChatId;
+          if (chatId) sendTrainingTelegramNotification(characterId, characterName, "failed", chatId, status.error);
+        }
         logger.error(`[Characters] Remote training failed for ${characterId}: ${status.error}`);
       } else if (status.lora_path) {
         characterRepo.update(characterId, {
@@ -1024,6 +1069,10 @@ function pollTrainingStatus(
           errorMessage: null,
         });
         _io?.emit("character:training:complete", { characterId, characterName });
+        if (notifyViaTelegram) {
+          const chatId = telegramChatId ?? _fallbackChatId;
+          if (chatId) sendTrainingTelegramNotification(characterId, characterName, "complete", chatId);
+        }
         logger.info(`[Characters] Remote training complete for ${characterId}: ${status.lora_path}`);
 
         // Clean up training data on the sidecar now that the character is confirmed ready.
@@ -1052,6 +1101,10 @@ function pollTrainingStatus(
           errorMessage: "Training completed but no LoRA adapter found in output directory",
         });
         _io?.emit("character:training:failed", { characterId, characterName });
+        if (notifyViaTelegram) {
+          const chatId = telegramChatId ?? _fallbackChatId;
+          if (chatId) sendTrainingTelegramNotification(characterId, characterName, "failed", chatId, "No LoRA adapter found");
+        }
         logger.error(`[Characters] Remote training completed but no LoRA found for ${characterId}`);
       }
     } catch (error) {

--- a/src/api/director.ts
+++ b/src/api/director.ts
@@ -3530,12 +3530,14 @@ Return ONLY the new narration text, no explanations or formatting.`;
         return;
       }
 
-      const { manifest, codec, crf, quality, draftId } = req.body as {
+      const { manifest, codec, crf, quality, draftId, notifyViaTelegram, telegramChatId } = req.body as {
         manifest: unknown;
         codec?: string;
         crf?: number;
         quality?: "draft" | "standard" | "high" | "lossless";
         draftId?: string;
+        notifyViaTelegram?: boolean;
+        telegramChatId?: string;
       };
       if (!manifest || typeof manifest !== "object") {
         res.status(400).json({ error: "manifest object is required" });
@@ -3554,6 +3556,8 @@ Return ONLY the new narration text, no explanations or formatting.`;
 
       const jobId = await renderOrchestrator.submit({
         manifest: manifest as import("../video/manifest/manifest-types.js").DirectorManifest,
+        notifyViaTelegram,
+        telegramChatId,
       });
 
       // Store quality metadata on the job for logging/display

--- a/src/api/queue.ts
+++ b/src/api/queue.ts
@@ -277,7 +277,7 @@ export const createQueueRouter = ({ queueMaster, repo, characterRepo, knowledgeS
   // ── POST /jobs — Submit a new media generation job ──────
   router.post("/jobs", (req, res) => {
     try {
-      const { type, payload, model, projectId, priority } = req.body as Partial<CreateMediaJobInput>;
+      const { type, payload, model, projectId, priority, notifyViaTelegram, telegramChatId } = req.body as Partial<CreateMediaJobInput>;
 
       if (!type || !VALID_JOB_TYPES.includes(type)) {
         res.status(400).json({ error: `Invalid job type. Must be one of: ${VALID_JOB_TYPES.join(", ")}` });
@@ -322,6 +322,8 @@ export const createQueueRouter = ({ queueMaster, repo, characterRepo, knowledgeS
         model,
         projectId: projectId ?? undefined,
         priority: priority ?? 0,
+        notifyViaTelegram: notifyViaTelegram ?? undefined,
+        telegramChatId: telegramChatId ?? undefined,
       });
 
       logger.info(`[QueueAPI] Job created: ${job.id} (${job.type} → ${job.targetNode})`);

--- a/src/mcp/tools/media-queue-tools.ts
+++ b/src/mcp/tools/media-queue-tools.ts
@@ -33,6 +33,8 @@ const submitMediaJobSchema = z.object({
   duration_seconds: z.number().optional().describe("Duration in seconds (music generation)"),
   lyrics: z.string().optional().describe("Lyrics for vocal music generation"),
   instrumental: z.boolean().optional().describe("Generate instrumental-only music"),
+  notify_via_telegram: z.boolean().optional().describe("Send a Telegram notification when the job completes or fails"),
+  telegram_chat_id: z.string().optional().describe("Telegram chat ID to notify (uses configured admin chat ID if omitted)"),
 });
 
 const getJobStatusSchema = z.object({
@@ -75,6 +77,8 @@ export const createMediaQueueTools = ({
           duration_seconds: { type: "number" },
           lyrics: { type: "string" },
           instrumental: { type: "boolean" },
+          notify_via_telegram: { type: "boolean", description: "Send a Telegram notification when the job completes or fails" },
+          telegram_chat_id: { type: "string", description: "Telegram chat ID to notify (uses configured admin chat ID if omitted)" },
         },
         required: ["type"],
       },
@@ -109,6 +113,8 @@ export const createMediaQueueTools = ({
             model,
             projectId: input.project_id,
             priority: input.priority ?? 0,
+            notifyViaTelegram: input.notify_via_telegram,
+            telegramChatId: input.telegram_chat_id,
           });
 
           return {

--- a/src/mcp/tools/remix-tools.ts
+++ b/src/mcp/tools/remix-tools.ts
@@ -16,6 +16,8 @@ const remixSessionSchema = z.object({
     .describe("Replacement instrument"),
   vibe: z.enum(["punchy_pop", "warm_lofi", "cinematic_wide", "raw"]).optional().describe("Mastering vibe preset"),
   reference_track_path: z.string().optional().describe("Reference audio path for mastering tonal matching"),
+  notify_via_telegram: z.boolean().optional().describe("Send a Telegram notification when the job completes or fails"),
+  telegram_chat_id: z.string().optional().describe("Telegram chat ID to notify (uses configured admin chat ID if omitted)"),
 });
 
 export type RemixToolsOptions = {
@@ -44,6 +46,8 @@ export const createRemixTools = ({ mediaQueueRepo }: RemixToolsOptions): ToolDef
           },
           vibe: { type: "string", enum: ["punchy_pop", "warm_lofi", "cinematic_wide", "raw"] },
           reference_track_path: { type: "string" },
+          notify_via_telegram: { type: "boolean", description: "Send a Telegram notification when the job completes or fails" },
+          telegram_chat_id: { type: "string", description: "Telegram chat ID to notify (uses configured admin chat ID if omitted)" },
         },
         required: ["action"],
       },
@@ -71,6 +75,8 @@ export const createRemixTools = ({ mediaQueueRepo }: RemixToolsOptions): ToolDef
                   device: "cpu",
                 },
                 model: "htdemucs_6s",
+                notifyViaTelegram: input.notify_via_telegram,
+                telegramChatId: input.telegram_chat_id,
               });
               return {
                 text: JSON.stringify({ job_id: job.id, status: job.status, action: "analyze" }),
@@ -114,6 +120,8 @@ export const createRemixTools = ({ mediaQueueRepo }: RemixToolsOptions): ToolDef
                   original_key: meta?.key as string | undefined,
                 },
                 model: "basic-pitch",
+                notifyViaTelegram: input.notify_via_telegram,
+                telegramChatId: input.telegram_chat_id,
               });
               return {
                 text: JSON.stringify({
@@ -145,6 +153,8 @@ export const createRemixTools = ({ mediaQueueRepo }: RemixToolsOptions): ToolDef
                   vibe: input.vibe ?? "raw",
                 },
                 model: "matchering",
+                notifyViaTelegram: input.notify_via_telegram,
+                telegramChatId: input.telegram_chat_id,
               });
               return {
                 text: JSON.stringify({

--- a/src/queue/media-notification-service.test.ts
+++ b/src/queue/media-notification-service.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { MediaNotificationService } from "./media-notification-service.js";
+import type { MediaJob } from "./types.js";
+import type { RenderJob, RenderResult } from "../video/render-types.js";
+
+// ── Test doubles ─────────────────────────────────────────────
+
+const silentLog = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+function createMockQueueMaster() {
+  const emitter = new EventEmitter();
+  return {
+    on: emitter.on.bind(emitter),
+    emit: emitter.emit.bind(emitter),
+  };
+}
+
+function createMockRenderOrchestrator() {
+  const emitter = new EventEmitter();
+  const jobs = new Map<string, Partial<RenderJob>>();
+  return {
+    on: emitter.on.bind(emitter),
+    emit: emitter.emit.bind(emitter),
+    getJob: (jobId: string) => jobs.get(jobId) ?? null,
+    _setJob: (jobId: string, job: Partial<RenderJob>) => jobs.set(jobId, job),
+  };
+}
+
+function createMockTelegram(connected = true) {
+  return {
+    isConnected: vi.fn().mockReturnValue(connected),
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createMockChannelManager(telegram?: ReturnType<typeof createMockTelegram>) {
+  return {
+    getChannel: vi.fn().mockImplementation((type: string) => type === "telegram" ? telegram : undefined),
+    broadcast: vi.fn(),
+    register: vi.fn(),
+    listChannels: vi.fn().mockReturnValue([]),
+  };
+}
+
+function makeMediaJob(overrides: Partial<MediaJob> = {}): MediaJob {
+  return {
+    id: "job-1",
+    type: "txt2img",
+    status: "complete",
+    requiredModel: "flux-schnell",
+    targetNode: "local",
+    payload: { prompt: "a sunset over mountains" },
+    resultUrl: "https://example.com/result.png",
+    resultMetadata: null,
+    error: null,
+    retryAfter: null,
+    createdAt: new Date(),
+    dispatchedAt: null,
+    completedAt: null,
+    notifyViaTelegram: false,
+    telegramChatId: null,
+    projectId: null,
+    galleryAssetId: null,
+    priority: 0,
+    retries: 0,
+    maxRetries: 3,
+    ...overrides,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe("MediaNotificationService", () => {
+  let queueMaster: ReturnType<typeof createMockQueueMaster>;
+  let renderOrchestrator: ReturnType<typeof createMockRenderOrchestrator>;
+  let telegram: ReturnType<typeof createMockTelegram>;
+  let channelManager: ReturnType<typeof createMockChannelManager>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queueMaster = createMockQueueMaster();
+    renderOrchestrator = createMockRenderOrchestrator();
+    telegram = createMockTelegram();
+    channelManager = createMockChannelManager(telegram);
+  });
+
+  function createService(fallbackChatId?: string) {
+    return new MediaNotificationService({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      queueMaster: queueMaster as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      renderOrchestrator: renderOrchestrator as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      channelManager: channelManager as any,
+      fallbackChatId,
+      log: silentLog,
+    });
+  }
+
+  // ── Queue job notifications ───────────────────────────────
+
+  it("sends Telegram notification on job:complete when opted in", async () => {
+    createService();
+    const job = makeMediaJob({ notifyViaTelegram: true, telegramChatId: "chat-abc" });
+
+    queueMaster.emit("job:complete", job);
+    await vi.runAllTimersAsync?.().catch(() => undefined);
+    await new Promise((r) => setImmediate(r));
+
+    expect(telegram.sendMessage).toHaveBeenCalledOnce();
+    const [chatId, content] = telegram.sendMessage.mock.calls[0];
+    expect(chatId).toBe("chat-abc");
+    expect(content.text).toContain("✅");
+    expect(content.text).toContain("sunset over mountains");
+    expect(content.markdown).toBe(true);
+  });
+
+  it("does not send notification on job:complete when not opted in", async () => {
+    createService();
+    queueMaster.emit("job:complete", makeMediaJob({ notifyViaTelegram: false }));
+    await new Promise((r) => setImmediate(r));
+
+    expect(telegram.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("sends failure notification on job:failed when opted in", async () => {
+    createService();
+    const job = makeMediaJob({ notifyViaTelegram: true, telegramChatId: "chat-abc" });
+
+    queueMaster.emit("job:failed", job, "GPU out of memory");
+    await new Promise((r) => setImmediate(r));
+
+    expect(telegram.sendMessage).toHaveBeenCalledOnce();
+    const [, content] = telegram.sendMessage.mock.calls[0];
+    expect(content.text).toContain("❌");
+    expect(content.text).toContain("GPU out of memory");
+  });
+
+  it("uses fallback chatId when job has no telegramChatId", async () => {
+    createService("fallback-chat-123");
+    const job = makeMediaJob({ notifyViaTelegram: true, telegramChatId: null });
+
+    queueMaster.emit("job:complete", job);
+    await new Promise((r) => setImmediate(r));
+
+    expect(telegram.sendMessage).toHaveBeenCalledOnce();
+    expect(telegram.sendMessage.mock.calls[0][0]).toBe("fallback-chat-123");
+  });
+
+  it("warns and skips when notifyViaTelegram=true but no chatId and no fallback", async () => {
+    createService(/* no fallback */);
+    const job = makeMediaJob({ notifyViaTelegram: true, telegramChatId: null });
+
+    queueMaster.emit("job:complete", job);
+    await new Promise((r) => setImmediate(r));
+
+    expect(telegram.sendMessage).not.toHaveBeenCalled();
+    expect(silentLog.warn).toHaveBeenCalledWith(expect.stringContaining("no chatId"));
+  });
+
+  it("gracefully degrades when telegram channel is not registered", async () => {
+    const mgr = createMockChannelManager(undefined /* no telegram */);
+    new MediaNotificationService({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      queueMaster: queueMaster as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      renderOrchestrator: renderOrchestrator as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      channelManager: mgr as any,
+      fallbackChatId: "chat-abc",
+      log: silentLog,
+    });
+
+    const job = makeMediaJob({ notifyViaTelegram: true, telegramChatId: "chat-abc" });
+    queueMaster.emit("job:complete", job);
+    await new Promise((r) => setImmediate(r));
+
+    expect(silentLog.warn).toHaveBeenCalledWith(expect.stringContaining("not registered"));
+  });
+
+  it("gracefully degrades when telegram channel is not connected", async () => {
+    telegram = createMockTelegram(false /* disconnected */);
+    channelManager = createMockChannelManager(telegram);
+    createService("chat-abc");
+
+    const job = makeMediaJob({ notifyViaTelegram: true, telegramChatId: "chat-abc" });
+    queueMaster.emit("job:complete", job);
+    await new Promise((r) => setImmediate(r));
+
+    expect(telegram.sendMessage).not.toHaveBeenCalled();
+    expect(silentLog.warn).toHaveBeenCalledWith(expect.stringContaining("not connected"));
+  });
+
+  // ── Render notifications ──────────────────────────────────
+
+  it("sends Telegram notification on render:complete when opted in", async () => {
+    createService();
+    renderOrchestrator._setJob("render-1", {
+      notifyViaTelegram: true,
+      telegramChatId: "chat-abc",
+      manifest: { projectTitle: "My Film" } as RenderJob["manifest"],
+    });
+
+    const result: RenderResult = {
+      jobId: "render-1",
+      success: true,
+      outputPath: "/outputs/my-film.mp4",
+      error: null,
+      durationSec: 42,
+      fileSizeBytes: 1024,
+    };
+    renderOrchestrator.emit("render:complete", result);
+    await new Promise((r) => setImmediate(r));
+
+    expect(telegram.sendMessage).toHaveBeenCalledOnce();
+    const [chatId, content] = telegram.sendMessage.mock.calls[0];
+    expect(chatId).toBe("chat-abc");
+    expect(content.text).toContain("🎬");
+    expect(content.text).toContain("My Film");
+    expect(content.text).toContain("my-film.mp4");
+  });
+
+  it("does not send notification on render:complete when not opted in", async () => {
+    createService();
+    renderOrchestrator._setJob("render-2", {
+      notifyViaTelegram: false,
+      manifest: { projectTitle: "Silent Film" } as RenderJob["manifest"],
+    });
+
+    renderOrchestrator.emit("render:complete", { jobId: "render-2", success: true, outputPath: "/out/f.mp4", error: null, durationSec: null, fileSizeBytes: null });
+    await new Promise((r) => setImmediate(r));
+
+    expect(telegram.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("sends failure notification on render:failed when opted in", async () => {
+    createService();
+    renderOrchestrator._setJob("render-3", {
+      notifyViaTelegram: true,
+      telegramChatId: "chat-xyz",
+      manifest: { projectTitle: "Epic Fail" } as RenderJob["manifest"],
+    });
+
+    renderOrchestrator.emit("render:failed", { jobId: "render-3", error: "Renderer crashed" });
+    await new Promise((r) => setImmediate(r));
+
+    expect(telegram.sendMessage).toHaveBeenCalledOnce();
+    const [, content] = telegram.sendMessage.mock.calls[0];
+    expect(content.text).toContain("❌");
+    expect(content.text).toContain("Epic Fail");
+    expect(content.text).toContain("Renderer crashed");
+  });
+
+  it("skips render:complete silently when job not found in orchestrator", async () => {
+    createService();
+    // No job set for "render-99"
+    renderOrchestrator.emit("render:complete", { jobId: "render-99", outputPath: "/out/x.mp4" });
+    await new Promise((r) => setImmediate(r));
+
+    expect(telegram.sendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/src/queue/media-notification-service.ts
+++ b/src/queue/media-notification-service.ts
@@ -1,0 +1,133 @@
+/**
+ * Media Notification Service
+ * Issue #414: Sends opt-in Telegram notifications when async media jobs complete or fail.
+ *
+ * Listens to QueueMaster and RenderOrchestrator events and routes notifications
+ * to TelegramChannel via ChannelManager. Gracefully degrades when Telegram is
+ * not configured or the chat ID is unknown.
+ */
+
+import { logger } from "../logging/logger.js";
+import type { ChannelManager } from "../channels/channel-manager.js";
+import type { QueueMaster } from "./queue-master.js";
+import type { MediaJob } from "./types.js";
+import type { RenderOrchestrator } from "../video/render-orchestrator.js";
+import type { RenderResult } from "../video/render-types.js";
+
+export type MediaNotificationServiceOptions = {
+  queueMaster: QueueMaster;
+  renderOrchestrator: RenderOrchestrator;
+  channelManager: ChannelManager;
+  /** Fallback Telegram chat ID when a job has notifyViaTelegram=true but no telegramChatId. */
+  fallbackChatId?: string;
+  /** For testing. */
+  log?: Pick<typeof logger, "info" | "warn" | "error">;
+};
+
+/**
+ * Wires up event listeners on QueueMaster and RenderOrchestrator.
+ * Constructed once at server startup — no teardown required for the app lifetime.
+ */
+export class MediaNotificationService {
+  private channelManager: ChannelManager;
+  private fallbackChatId: string | undefined;
+  private log: Pick<typeof logger, "info" | "warn" | "error">;
+
+  constructor({
+    queueMaster,
+    renderOrchestrator,
+    channelManager,
+    fallbackChatId,
+    log: logOverride,
+  }: MediaNotificationServiceOptions) {
+    this.channelManager = channelManager;
+    this.fallbackChatId = fallbackChatId;
+    this.log = logOverride ?? logger;
+
+    // ── QueueMaster events ──────────────────────────────────
+    queueMaster.on("job:complete", (job: MediaJob) => {
+      void this.notifyJob(job, "complete").catch((err) => {
+        this.log.error(`[MediaNotificationService] error: ${err instanceof Error ? err.message : String(err)}`);
+      });
+    });
+
+    queueMaster.on("job:failed", (job: MediaJob, error: string) => {
+      void this.notifyJob(job, "failed", error).catch((err) => {
+        this.log.error(`[MediaNotificationService] error: ${err instanceof Error ? err.message : String(err)}`);
+      });
+    });
+
+    // ── RenderOrchestrator events ───────────────────────────
+    renderOrchestrator.on("render:complete", (result: RenderResult) => {
+      const renderJob = renderOrchestrator.getJob(result.jobId);
+      if (!renderJob?.notifyViaTelegram) return;
+
+      const chatId = renderJob.telegramChatId ?? this.fallbackChatId;
+      if (!chatId) {
+        this.log.warn(`[MediaNotificationService] render:complete — notifyViaTelegram=true but no chatId for job ${result.jobId}`);
+        return;
+      }
+
+      const title = renderJob.manifest.projectTitle ?? result.jobId;
+      const secs = result.durationSec ? ` (${Math.round(result.durationSec)}s)` : "";
+      const text = `🎬 Render complete: *${title}*${secs}\nOutput: \`${result.outputPath ?? "unknown"}\``;
+      void this.send(chatId, text, result.jobId, "render").catch(() => {/* logged in send() */});
+    });
+
+    renderOrchestrator.on("render:failed", (data: { jobId: string; error: string }) => {
+      const renderJob = renderOrchestrator.getJob(data.jobId);
+      if (!renderJob?.notifyViaTelegram) return;
+
+      const chatId = renderJob.telegramChatId ?? this.fallbackChatId;
+      if (!chatId) return;
+
+      const title = renderJob.manifest.projectTitle ?? data.jobId;
+      const text = `❌ Render failed: *${title}*\nError: ${data.error}`;
+      void this.send(chatId, text, data.jobId, "render").catch(() => {/* logged in send() */});
+    });
+  }
+
+  private async notifyJob(job: MediaJob, outcome: "complete" | "failed", error?: string): Promise<void> {
+    if (!job.notifyViaTelegram) return;
+
+    const chatId = job.telegramChatId ?? this.fallbackChatId;
+    if (!chatId) {
+      this.log.warn(`[MediaNotificationService] job:${outcome} — notifyViaTelegram=true but no chatId for job ${job.id}`);
+      return;
+    }
+
+    const label = job.payload.prompt
+      ? `"${job.payload.prompt.slice(0, 60)}${job.payload.prompt.length > 60 ? "…" : ""}"`
+      : job.type;
+
+    let text: string;
+    if (outcome === "complete") {
+      text = `✅ Media job complete: *${label}*\nType: \`${job.type}\``;
+      if (job.resultUrl) text += `\nResult: ${job.resultUrl}`;
+    } else {
+      text = `❌ Media job failed: *${label}*\nType: \`${job.type}\`\nError: ${error ?? "unknown"}`;
+    }
+
+    await this.send(chatId, text, job.id, "queue");
+  }
+
+  private async send(chatId: string, text: string, jobId: string, source: string): Promise<void> {
+    const telegram = this.channelManager.getChannel("telegram");
+    if (!telegram) {
+      this.log.warn(`[MediaNotificationService] Telegram channel not registered — cannot notify for ${source} job ${jobId}`);
+      return;
+    }
+    if (!telegram.isConnected()) {
+      this.log.warn(`[MediaNotificationService] Telegram not connected — skipping notification for ${source} job ${jobId}`);
+      return;
+    }
+    try {
+      await telegram.sendMessage(chatId, { text, markdown: true });
+      this.log.info(`[MediaNotificationService] Telegram notification sent to ${chatId} for ${source} job ${jobId}`);
+    } catch (err) {
+      this.log.error(
+        `[MediaNotificationService] Failed to send Telegram notification for ${source} job ${jobId}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+}

--- a/src/queue/media-queue-repository.ts
+++ b/src/queue/media-queue-repository.ts
@@ -36,6 +36,8 @@ const toJob = (row: StoredMediaJob): MediaJob => ({
   createdAt: new Date(row.created_at),
   dispatchedAt: row.dispatched_at ? new Date(row.dispatched_at) : null,
   completedAt: row.completed_at ? new Date(row.completed_at) : null,
+  notifyViaTelegram: row.notify_via_telegram === 1,
+  telegramChatId: row.telegram_chat_id,
 });
 
 // ── Repository ────────────────────────────────────────────────
@@ -336,6 +338,15 @@ export class MediaQueueRepository {
     if (!assetCols.includes("knowledge_category")) {
       this.db.exec("ALTER TABLE media_assets ADD COLUMN knowledge_category TEXT NOT NULL DEFAULT 'media'");
     }
+
+    // ── Telegram notification columns (additive migration, Issue #414) ──
+    const jobCols = (this.db.prepare("PRAGMA table_info(media_jobs)").all() as Array<{ name: string }>).map((c) => c.name);
+    if (!jobCols.includes("notify_via_telegram")) {
+      this.db.exec("ALTER TABLE media_jobs ADD COLUMN notify_via_telegram INTEGER NOT NULL DEFAULT 0");
+    }
+    if (!jobCols.includes("telegram_chat_id")) {
+      this.db.exec("ALTER TABLE media_jobs ADD COLUMN telegram_chat_id TEXT");
+    }
   }
 
   // ── Media Jobs CRUD ───────────────────────────────────────
@@ -347,8 +358,8 @@ export class MediaQueueRepository {
     const targetNode = targetNodeForJobType(input.type);
 
     const stmt = this.db.prepare(`
-      INSERT INTO media_jobs (id, type, required_model, target_node, payload, status, project_id, priority, created_at)
-      VALUES (?, ?, ?, ?, ?, 'pending', ?, ?, ?)
+      INSERT INTO media_jobs (id, type, required_model, target_node, payload, status, project_id, priority, created_at, notify_via_telegram, telegram_chat_id)
+      VALUES (?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?)
     `);
 
     stmt.run(
@@ -360,6 +371,8 @@ export class MediaQueueRepository {
       input.projectId ?? null,
       input.priority ?? 0,
       now,
+      input.notifyViaTelegram ? 1 : 0,
+      input.telegramChatId ?? null,
     );
 
     return this.getJob(id)!;

--- a/src/queue/queue-master.test.ts
+++ b/src/queue/queue-master.test.ts
@@ -37,6 +37,8 @@ function makeJob(overrides: Partial<MediaJob> = {}): MediaJob {
     createdAt: new Date(),
     dispatchedAt: null,
     completedAt: null,
+    notifyViaTelegram: false,
+    telegramChatId: null,
     ...overrides,
   };
 }

--- a/src/queue/types.ts
+++ b/src/queue/types.ts
@@ -170,6 +170,8 @@ export interface StoredMediaJob {
   created_at: string;
   dispatched_at: string | null;
   completed_at: string | null;
+  notify_via_telegram: number;  // 0 or 1 (SQLite boolean)
+  telegram_chat_id: string | null;
 }
 
 /** Domain-level media job (parsed from stored row). */
@@ -192,6 +194,8 @@ export interface MediaJob {
   createdAt: Date;
   dispatchedAt: Date | null;
   completedAt: Date | null;
+  notifyViaTelegram: boolean;
+  telegramChatId: string | null;
 }
 
 // ── Create Job Input ──────────────────────────────────────────
@@ -202,6 +206,8 @@ export interface CreateMediaJobInput {
   model?: string;
   projectId?: string;
   priority?: number;
+  notifyViaTelegram?: boolean;
+  telegramChatId?: string;
 }
 
 // ── Worker Status ─────────────────────────────────────────────

--- a/src/server.ts
+++ b/src/server.ts
@@ -75,9 +75,10 @@ import { RoomManager } from "./presenter/room-manager.js";
 import { ExpressPeerServer } from "peer";
 import { MediaQueueRepository } from "./queue/media-queue-repository.js";
 import { QueueMaster } from "./queue/queue-master.js";
+import { MediaNotificationService } from "./queue/media-notification-service.js";
 import { createQueueRouter, createQueueCallbackRouter } from "./api/queue.js";
 import { createGalleryRouter } from "./api/gallery.js";
-import { createCharacterRouter, setCharacterIO, resumeStaleTrainingPolls } from "./api/characters.js";
+import { createCharacterRouter, setCharacterIO, setCharacterChannelManager, resumeStaleTrainingPolls } from "./api/characters.js";
 import { CharacterRepository } from "./characters/character-repository.js";
 
 // Register built-in post-action types (create-github-issues, send-webhook, etc.)
@@ -1199,6 +1200,8 @@ const io = new SocketIOServer(httpServer, {
 setDirectorIO(io);
 // Bind Socket.IO to Character router for training progress events
 setCharacterIO(io);
+// Wire ChannelManager into Character router for opt-in Telegram training notifications (Issue #415)
+setCharacterChannelManager(channelManager, config.channels?.telegram?.adminUserId || undefined);
 // Resume polling for any characters stuck in "training" after server restart
 resumeStaleTrainingPolls(characterRepo).catch((err) => {
   logger.warn(`[Characters] Failed to resume stale training polls: ${err}`);
@@ -1616,6 +1619,14 @@ new NotificationDispatcher({
   channelManager,
   sessionManager,
   io,
+});
+
+// Wire MediaNotificationService — per-job opt-in Telegram notifications (Issue #414)
+new MediaNotificationService({
+  queueMaster,
+  renderOrchestrator,
+  channelManager,
+  fallbackChatId: config.channels?.telegram?.adminUserId || undefined,
 });
 
 // Forward ALL task lifecycle events to Socket.IO for real-time graph updates

--- a/src/skills/media-director/SKILL.md
+++ b/src/skills/media-director/SKILL.md
@@ -72,3 +72,9 @@ For multi-asset projects (e.g., "Create a thumbnail and a promo video"):
   - If `manage-characters` fails → proceed without LoRA and inform the user.
 - After 2 failed alternatives, stop and explain the issue to the user with suggested remediation steps.
 - NEVER silently swallow errors — always inform the user what happened and what was tried.
+
+## Telegram Notifications
+- Any `submit-media-job` call can include `notify_via_telegram: true` to send the user a Telegram message when the job completes or fails.
+- Optionally pass `telegram_chat_id` to route to a specific chat; otherwise the admin chat ID is used as fallback.
+- When a user says "send me a Telegram when done" or similar, always set `notify_via_telegram: true` on the job submission.
+- You do NOT need to poll `get-job-status` when notifications are enabled — the system will push the update automatically.

--- a/src/skills/remix-engineer/SKILL.md
+++ b/src/skills/remix-engineer/SKILL.md
@@ -68,3 +68,8 @@ NEVER attempt to master before analysis. NEVER replace a stem without analysis r
 - If mastering fails → retry without the reference track (fall back to LUFS -14 normalization).
 - After 2 failed alternatives, stop and explain the issue clearly.
 - NEVER silently skip a pipeline step — the remix pipeline must be executed in order.
+
+## Telegram Notifications
+- Any `remix-session-manager` call (analyze, replace_stem, master) can include `notify_via_telegram: true` to send a Telegram message on completion or failure.
+- Optionally pass `telegram_chat_id` to target a specific chat; omit it to use the admin fallback.
+- When the user requests a notification on completion, set `notify_via_telegram: true` on the **master** step (final step of the pipeline).

--- a/src/video/render-orchestrator.ts
+++ b/src/video/render-orchestrator.ts
@@ -68,6 +68,8 @@ export class RenderOrchestrator extends EventEmitter {
       updatedAt: now,
       durationSec: null,
       fileSizeBytes: null,
+      notifyViaTelegram: request.notifyViaTelegram ?? false,
+      telegramChatId: request.telegramChatId ?? null,
     };
 
     this.jobs.set(jobId, job);

--- a/src/video/render-types.ts
+++ b/src/video/render-types.ts
@@ -20,6 +20,10 @@ export interface RenderJob {
   durationSec: number | null;
   /** File size of the rendered output in bytes (set on completion). */
   fileSizeBytes: number | null;
+  /** Whether to send a Telegram notification when this render completes. */
+  notifyViaTelegram: boolean;
+  /** Telegram chat ID to notify (falls back to configured adminUserId if null). */
+  telegramChatId: string | null;
 }
 
 export interface RenderProgress {
@@ -35,6 +39,10 @@ export interface RenderRequest {
   manifest: DirectorManifest;
   /** Override the output directory (default: ~/.openzigs/renders/{jobId}/) */
   outputDir?: string;
+  /** Whether to send a Telegram notification when the render completes. */
+  notifyViaTelegram?: boolean;
+  /** Telegram chat ID to notify (falls back to configured adminUserId if null). */
+  telegramChatId?: string;
 }
 
 export interface RenderResult {

--- a/ui/app/characters/page.tsx
+++ b/ui/app/characters/page.tsx
@@ -7,6 +7,7 @@ import { buildMediaUrl } from "@/lib/api";
 import { SectionCard } from "@/components/section-card";
 import { ToastContainer, showToast } from "@/components/toast";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { TelegramNotifyToggle } from "@/components/telegram-notify-toggle";
 import {
   User,
   Plus,
@@ -86,6 +87,7 @@ export default function CharactersPage() {
   const [trainLR, setTrainLR] = useState(0.0001);
   const [trainRank, setTrainRank] = useState(16);
   const [trainEpochs, setTrainEpochs] = useState(50);
+  const [trainNotifyViaTelegram, setTrainNotifyViaTelegram] = useState(false);
 
   // AI Enhance model selection dialog
   const [showEnhanceDialog, setShowEnhanceDialog] = useState(false);
@@ -171,10 +173,10 @@ export default function CharactersPage() {
   });
 
   const trainMutation = useMutation({
-    mutationFn: (data: { id: string; steps: number; learningRate: number; loraRank: number; numEpochs: number }) =>
+    mutationFn: (data: { id: string; steps: number; learningRate: number; loraRank: number; numEpochs: number; notifyViaTelegram?: boolean }) =>
       fetchJson<{ ok: boolean; message: string }>(`/api/characters/${data.id}/train`, {
         method: "POST",
-        body: JSON.stringify({ steps: data.steps, learningRate: data.learningRate, loraRank: data.loraRank, numEpochs: data.numEpochs }),
+        body: JSON.stringify({ steps: data.steps, learningRate: data.learningRate, loraRank: data.loraRank, numEpochs: data.numEpochs, notifyViaTelegram: data.notifyViaTelegram }),
       }),
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ["characters"] });
@@ -738,6 +740,7 @@ export default function CharactersPage() {
                         learningRate: trainLR,
                         loraRank: trainRank,
                         numEpochs: trainEpochs,
+                        notifyViaTelegram: trainNotifyViaTelegram || undefined,
                       })
                     }
                     disabled={
@@ -754,6 +757,12 @@ export default function CharactersPage() {
                     )}
                     {selected.status === "training" ? "Training in Progress..." : "Start Training"}
                   </button>
+                  <TelegramNotifyToggle
+                    compact
+                    checked={trainNotifyViaTelegram}
+                    onChange={setTrainNotifyViaTelegram}
+                    disabled={trainMutation.isPending || selected.status === "training"}
+                  />
                   {selected.status === "training" && (
                     <button
                       onClick={() =>

--- a/ui/components/director/review-produce-step.tsx
+++ b/ui/components/director/review-produce-step.tsx
@@ -29,6 +29,7 @@ import {
 import type { WizardState, RenderJobStatus, DirectorManifestSummary, RenderSettings, RenderQuality, ImageProvider, ImageModel } from "./types";
 import { QUALITY_PRESETS } from "./types";
 import type { ModelInfo } from "@/lib/types";
+import { TelegramNotifyToggle } from "@/components/telegram-notify-toggle";
 
 interface ReviewProduceStepProps {
   state: WizardState;
@@ -98,6 +99,7 @@ export const ReviewProduceStep = ({
   const [framesInfo, setFramesInfo] = useState<string | null>(null);
   const [enableVisionAnalysis, setEnableVisionAnalysis] = useState(true);
   const [produceElapsedSec, setProduceElapsedSec] = useState(0);
+  const [notifyViaTelegram, setNotifyViaTelegram] = useState(false);
 
   // Fetch available models for the model picker
   const modelsQuery = useQuery({
@@ -203,6 +205,7 @@ export const ReviewProduceStep = ({
             visualAssets: visualAssets.length > 0 ? visualAssets : undefined,
             brandVoiceId: state.brandVoiceId || undefined,
             imageClipDurationSeconds: state.imageClipDurationSeconds,
+            notifyViaTelegram: notifyViaTelegram || undefined,
           }),
         });
       }
@@ -218,6 +221,7 @@ export const ReviewProduceStep = ({
           model: state.model || undefined,
           enableVisionAnalysis,
           brandVoiceId: state.brandVoiceId || undefined,
+          notifyViaTelegram: notifyViaTelegram || undefined,
         }),
       });
     },
@@ -274,6 +278,7 @@ export const ReviewProduceStep = ({
           codec: state.renderSettings.codec,
           crf: state.renderSettings.crf,
           quality: state.renderSettings.quality,
+          notifyViaTelegram: notifyViaTelegram || undefined,
         }),
       }),
     onSuccess: (data) => {
@@ -634,6 +639,14 @@ export const ReviewProduceStep = ({
                 }`}
               />
             </button>
+          </div>
+
+          {/* Telegram Notification Toggle */}
+          <div className="flex items-center justify-between rounded-xl border border-border bg-card px-4 py-3">
+            <TelegramNotifyToggle
+              checked={notifyViaTelegram}
+              onChange={setNotifyViaTelegram}
+            />
           </div>
 
           <div className="flex items-center gap-2">

--- a/ui/components/music-studio/SmartRemixLab.tsx
+++ b/ui/components/music-studio/SmartRemixLab.tsx
@@ -8,6 +8,7 @@ import { SectionCard } from "@/components/section-card";
 import { showToast } from "@/components/toast";
 import type WaveSurfer from "wavesurfer.js";
 import { WaveformTrack } from "./WaveformTrack";
+import { TelegramNotifyToggle } from "@/components/telegram-notify-toggle";
 import {
   Wand2,
   Volume2,
@@ -130,6 +131,7 @@ export function SmartRemixLab({ audioAssets }: SmartRemixLabProps) {
   const [analyzeJobId, setAnalyzeJobId] = useState<string | null>(null);
   const [gallerySaving, setGallerySaving] = useState(false);
   const [quickMixJobId, setQuickMixJobId] = useState<string | null>(null);
+  const [notifyViaTelegram, setNotifyViaTelegram] = useState(false);
   const pollRef = useRef<Set<ReturnType<typeof setInterval>>>(new Set());
 
   // ── Stem Playback ─────────────────────────────────────────
@@ -154,6 +156,7 @@ export function SmartRemixLab({ audioAssets }: SmartRemixLabProps) {
           payload: {
             source_asset_id: assetId,
           },
+          notify_via_telegram: notifyViaTelegram || undefined,
         }),
       });
       return res;
@@ -248,6 +251,7 @@ export function SmartRemixLab({ audioAssets }: SmartRemixLabProps) {
             muted,
             vibe,
           },
+          notify_via_telegram: notifyViaTelegram || undefined,
         }),
       });
       return res;
@@ -290,6 +294,7 @@ export function SmartRemixLab({ audioAssets }: SmartRemixLabProps) {
             vibe,
             skip_mastering: true,
           },
+          notify_via_telegram: notifyViaTelegram || undefined,
         }),
       });
       return res;
@@ -770,6 +775,15 @@ export function SmartRemixLab({ audioAssets }: SmartRemixLabProps) {
               )}
               {isAnalyzing ? "Analyzing..." : "Analyze & Split"}
             </button>
+          </div>
+
+          {/* Telegram Notification Toggle */}
+          <div className="flex items-center justify-between rounded-lg border border-zinc-700 bg-zinc-900/50 px-3 py-2">
+            <TelegramNotifyToggle
+              checked={notifyViaTelegram}
+              onChange={setNotifyViaTelegram}
+              compact
+            />
           </div>
 
           {/* Analysis Progress */}

--- a/ui/components/telegram-notify-toggle.tsx
+++ b/ui/components/telegram-notify-toggle.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+type TelegramNotifyToggleProps = {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  disabled?: boolean;
+  /** Compact mode for inline use in forms */
+  compact?: boolean;
+};
+
+export function TelegramNotifyToggle({ checked, onChange, disabled, compact }: TelegramNotifyToggleProps) {
+  return (
+    <label
+      className={cn(
+        "flex items-center gap-2 cursor-pointer select-none",
+        compact ? "text-xs" : "text-sm",
+        disabled && "opacity-50 cursor-not-allowed"
+      )}
+    >
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        disabled={disabled}
+        onClick={() => onChange(!checked)}
+        className={cn(
+          "relative inline-flex h-5 w-9 shrink-0 rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          checked ? "bg-[#0088cc]" : "bg-muted-foreground/30"
+        )}
+      >
+        <span
+          className={cn(
+            "pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
+            checked ? "translate-x-4" : "translate-x-0"
+          )}
+        />
+      </button>
+      <span className="flex items-center gap-1.5">
+        {/* Telegram paper-plane icon (inline SVG, 16×16) */}
+        <svg viewBox="0 0 24 24" className="h-4 w-4 text-[#0088cc]" fill="currentColor" aria-hidden>
+          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm4.64 6.8c-.15 1.58-.8 5.42-1.13 7.19-.14.75-.42 1-.68 1.03-.58.05-1.02-.38-1.58-.75-.88-.58-1.38-.94-2.23-1.5-.99-.65-.35-1.01.22-1.59.15-.15 2.71-2.48 2.76-2.69a.2.2 0 00-.05-.18c-.06-.05-.14-.03-.21-.02-.09.02-1.49.95-4.22 2.79-.4.27-.76.41-1.08.4-.36-.01-1.04-.2-1.55-.37-.63-.2-1.12-.31-1.08-.66.02-.18.27-.36.74-.55 2.92-1.27 4.86-2.11 5.83-2.51 2.78-1.16 3.35-1.36 3.73-1.36.08 0 .27.02.39.12.1.08.13.19.14.27-.01.06.01.24 0 .38z" />
+        </svg>
+        <span className={cn("text-muted-foreground", checked && "text-foreground")}>
+          Notify via Telegram
+        </span>
+      </span>
+    </label>
+  );
+}


### PR DESCRIPTION
## Summary

Implements Epic #413 and all sub-issues. Users can now opt-in to receive a Telegram message when long-running async operations complete or fail — without polling or leaving the browser open.

Closes #413, #414, #415, #416, #417

---

## What Changed

### Backend (Issue #414)
- Added `notifyViaTelegram: boolean` and `telegramChatId: string | null` to `MediaJob`, `StoredMediaJob`, `CreateMediaJobInput`, `RenderJob`, and `RenderRequest`
- Additive SQLite migration adds `notify_via_telegram INTEGER NOT NULL DEFAULT 0` and `telegram_chat_id TEXT` to `media_jobs` (WAL-safe, using `PRAGMA table_info` guard)
- New `MediaNotificationService` (`src/queue/media-notification-service.ts`) listens to:
  - `QueueMaster` events: `job:complete`, `job:failed`
  - `RenderOrchestrator` events: `render:complete`, `render:failed`
  - Gracefully degrades when Telegram is not configured or not connected
- Character training (`startRemoteTraining` / `pollTrainingStatus`) accepts notification fields; `sendTrainingTelegramNotification()` fires on all terminal outcomes (complete, partial-timeout-complete, failed, no-LoRA)
- `setCharacterChannelManager()` setter wired in `server.ts` (mirrors `setCharacterIO` pattern)

### API Passthrough (Issue #416)
- `POST /api/queue/jobs` — passes `notifyViaTelegram` + `telegramChatId` to `MediaQueueRepository.createJob()`
- `POST /api/admin/director/render` — passes fields to `RenderOrchestrator.submit()`
- `submit-media-job` MCP tool — `notify_via_telegram` + `telegram_chat_id` added to Zod schema and JSON `inputSchema`
- `remix-session-manager` MCP tool — same fields on all 3 actions (analyze, replace_stem, master)

### UI (Issue #415)
- New reusable `TelegramNotifyToggle` component (`ui/components/telegram-notify-toggle.tsx`) — Telegram blue `#0088cc`, paper-plane SVG icon, compact variant
- Toggle added to:
  - **Director > Review & Produce step** — between vision analysis toggle and render quality settings
  - **Music Studio > Smart Remix Lab** — below the Analyze button
  - **Characters > LoRA Training panel** — next to the Start Training button

### Skills (Issue #417)
- `media-director/SKILL.md` — added `## Telegram Notifications` section: agent should set `notify_via_telegram: true` when user asks for a notification
- `remix-engineer/SKILL.md` — added `## Telegram Notifications` section: set on the master step (final step of the pipeline)

### Tests
- `src/queue/media-notification-service.test.ts` — 11 unit tests:
  - `job:complete` opted-in → `sendMessage` called with `✅` text
  - `job:complete` not opted-in → no call
  - `job:failed` opted-in → `sendMessage` called with `❌` + error text
  - Fallback chatId used when job has no `telegramChatId`
  - Warn + skip when no chatId and no fallback
  - Graceful degradation when telegram not registered
  - Graceful degradation when telegram not connected
  - `render:complete` opted-in → notification with title and output path
  - `render:complete` not opted-in → no call
  - `render:failed` opted-in → failure notification
  - `render:complete` for unknown job → silent skip

### Docs
- `docs/USER_GUIDE.md` — new "Telegram Notifications for Async Jobs" section before the Media Queue section (table of surfaces, requirements, agentic use)
- `docs/ARCHITECTURE.md` — added `MediaNotificationService` to the async systems component table and a detailed subsection under Queue Master

---

## Quality Gates
- `pnpm typecheck` ✅
- `pnpm lint` ✅  
- `pnpm test --run` ✅ (186 test files, 3384 tests)
- `cd ui && npx next build` ✅