### PR TITLE
fix: Resolve #542 — Dependency security fixes (Q1 2026 audit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Bump jspdf 4.2.0 → 4.2.1 to fix prototype pollution vulnerability (CVE-2025-26791)
+- Add pnpm override for socket.io-parser ≥4.2.6 (CVE-2025-27108 — insufficient input validation)
+- Update pnpm override for undici ≥6.23.0 → ≥7.24.0 (CVE-2025-22150 — insufficient randomness in request boundary)
+- Add pnpm override for flatted ≥3.4.2 (CVE-2025-27490 — prototype pollution)
+
 ## [0.1.0] - 2026-03-22
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -106,8 +106,10 @@
     "overrides": {
       "glob": ">=10.5.0",
       "serialize-javascript": ">=7.0.3",
-      "undici": ">=6.23.0",
-      "esbuild": ">=0.25.0"
+      "undici": ">=7.24.0",
+      "esbuild": ">=0.25.0",
+      "socket.io-parser": ">=4.2.6",
+      "flatted": ">=3.4.2"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,10 @@ settings:
 overrides:
   glob: '>=10.5.0'
   serialize-javascript: '>=7.0.3'
-  undici: '>=6.23.0'
+  undici: '>=7.24.0'
   esbuild: '>=0.25.0'
+  socket.io-parser: '>=4.2.6'
+  flatted: '>=3.4.2'
 
 importers:
 
@@ -268,11 +270,11 @@ importers:
         specifier: ^6.1.3
         version: 6.1.3
       jspdf:
-        specifier: ^4.2.0
-        version: 4.2.0
+        specifier: ^4.2.1
+        version: 4.2.1
       jspdf-autotable:
         specifier: ^5.0.7
-        version: 5.0.7(jspdf@4.2.0)
+        version: 5.0.7(jspdf@4.2.1)
       lucide-react:
         specifier: ^0.575.0
         version: 0.575.0(react@18.3.1)
@@ -4817,8 +4819,8 @@ packages:
   flatbuffers@25.9.23:
     resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
 
-  flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   fluent-ffmpeg@2.1.3:
     resolution: {integrity: sha512-Be3narBNt2s6bsaqP6Jzq91heDgOEaDCJAXcE3qcma/EJBSy5FB4cvO31XBInuAuKBx8Kptf8dkhjK0IOru39Q==}
@@ -5462,8 +5464,8 @@ packages:
     peerDependencies:
       jspdf: ^2 || ^3 || ^4
 
-  jspdf@4.2.0:
-    resolution: {integrity: sha512-hR/hnRevAXXlrjeqU5oahOE+Ln9ORJUB5brLHHqH67A+RBQZuFr5GkbI9XQI8OUFSEezKegsi45QRpc4bGj75Q==}
+  jspdf@4.2.1:
+    resolution: {integrity: sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==}
 
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
@@ -6899,8 +6901,8 @@ packages:
     resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
     engines: {node: '>=10.0.0'}
 
-  socket.io-parser@4.2.5:
-    resolution: {integrity: sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==}
+  socket.io-parser@4.2.6:
+    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
     engines: {node: '>=10.0.0'}
 
   socket.io@4.8.3:
@@ -7391,8 +7393,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@7.22.0:
-    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
+  undici@7.24.5:
+    resolution: {integrity: sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==}
     engines: {node: '>=20.18.1'}
 
   unidiff@1.0.4:
@@ -8374,7 +8376,7 @@ snapshots:
       discord-api-types: 0.38.40
       magic-bytes.js: 1.13.0
       tslib: 2.8.1
-      undici: 7.22.0
+      undici: 7.24.5
 
   '@discordjs/util@1.2.0':
     dependencies:
@@ -12128,7 +12130,7 @@ snapshots:
       lodash.snakecase: 4.1.1
       magic-bytes.js: 1.13.0
       tslib: 2.8.1
-      undici: 7.22.0
+      undici: 7.24.5
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -12924,7 +12926,7 @@ snapshots:
 
   flat-cache@3.2.0:
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.4.2
       keyv: 4.5.4
       rimraf: 3.0.2
 
@@ -12932,7 +12934,7 @@ snapshots:
 
   flatbuffers@25.9.23: {}
 
-  flatted@3.3.3: {}
+  flatted@3.4.2: {}
 
   fluent-ffmpeg@2.1.3:
     dependencies:
@@ -13576,7 +13578,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.0
-      undici: 7.22.0
+      undici: 7.24.5
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -13614,11 +13616,11 @@ snapshots:
 
   json5@2.2.3: {}
 
-  jspdf-autotable@5.0.7(jspdf@4.2.0):
+  jspdf-autotable@5.0.7(jspdf@4.2.1):
     dependencies:
-      jspdf: 4.2.0
+      jspdf: 4.2.1
 
-  jspdf@4.2.0:
+  jspdf@4.2.1:
     dependencies:
       '@babel/runtime': 7.28.6
       fast-png: 6.4.0
@@ -15549,13 +15551,13 @@ snapshots:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3
       engine.io-client: 6.6.4
-      socket.io-parser: 4.2.5
+      socket.io-parser: 4.2.6
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socket.io-parser@4.2.5:
+  socket.io-parser@4.2.6:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3
@@ -15570,7 +15572,7 @@ snapshots:
       debug: 4.4.3
       engine.io: 6.6.5
       socket.io-adapter: 2.5.6
-      socket.io-parser: 4.2.5
+      socket.io-parser: 4.2.6
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -16113,7 +16115,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@7.22.0: {}
+  undici@7.24.5: {}
 
   unidiff@1.0.4:
     dependencies:

--- a/ui/package.json
+++ b/ui/package.json
@@ -44,7 +44,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "jose": "^6.1.3",
-    "jspdf": "^4.2.0",
+    "jspdf": "^4.2.1",
     "jspdf-autotable": "^5.0.7",
     "lucide-react": "^0.575.0",
     "mermaid": "^11.12.3",


### PR DESCRIPTION
## Summary

Resolves all sub-issues from the Q1 2026 Dependabot security audit epic. Bumps vulnerable direct dependencies, adds pnpm overrides for transitive dependency CVEs, and dismisses false-positive alerts.

## Changes

### #543 — Bump jspdf 4.2.0 → 4.2.1
- `ui/package.json`: updated `jspdf` to `^4.2.1` (fixes CVE-2025-26791 — prototype pollution)

### #544 — Add socket.io-parser pnpm override ≥4.2.6
- `package.json`: added `"socket.io-parser": ">=4.2.6"` to `pnpm.overrides` (fixes CVE-2025-27108 — insufficient input validation)

### #546 — Update undici pnpm override to ≥7.24.0
- `package.json`: updated `"undici"` override from `>=6.23.0` to `>=7.24.0` (fixes CVE-2025-22150 — insufficient randomness in request boundary)

### #547 — Add flatted pnpm override ≥3.4.2
- `package.json`: added `"flatted": ">=3.4.2"` to `pnpm.overrides` (fixes CVE-2025-27490 — prototype pollution)

### #545 — Dismiss false-positive Dependabot alerts
- Dismissed alerts #32 (ajv) and #33–#38 (minimatch) as `inaccurate` — installed versions (ajv 8.18.0, minimatch 9.0.9) are well above the vulnerable ranges

## Quality Gate

- ✅ `pnpm lint` — clean
- ✅ `pnpm typecheck` — clean
- ✅ `pnpm test` — 4851/4852 passed (1 pre-existing failure in `presenter.test.ts`, unrelated to this PR)
- ✅ `cd ui && npx next build` — clean

## Security

All changes are security-focused dependency updates. No application logic modified.

Closes #542
Closes #543
Closes #544
Closes #545
Closes #546
Closes #547