### PR TITLE
fix: allow private LAN IPs for network node health checks

### DIFF
--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -33,7 +33,7 @@ import { TemplateService } from "../productivity/template-service.js";
 import { CopilotNativeMcpTester, type NativeMcpDiscoveredTool, type NativeMcpTester } from "../mcp/native-mcp-test-service.js";
 import { AVAILABLE_VOICES } from "../voice/types.js";
 import { loadSkillMetadata } from "../skills/skill-loader.js";
-import { isAllowedWebhookUrl } from "../security/url-validation.js";
+import { isAllowedNetworkNodeUrl } from "../security/url-validation.js";
 import type { PipelineTemplateManager } from "../productivity/pipeline-template-manager.js";
 import type { Server as SocketIOServer } from "socket.io";
 import { CronExpressionParser } from "cron-parser";
@@ -3820,7 +3820,7 @@ export const createAdminRouter = ({ toolRegistry, sidecarManager, localServerMan
       if (!/^https?:\/\/.+/.test(url)) {
         return res.status(400).json({ error: "url must be a valid HTTP(S) URL" });
       }
-      if (!isAllowedWebhookUrl(url)) {
+      if (!isAllowedNetworkNodeUrl(url)) {
         return res.status(400).json({ error: "URL points to a blocked internal/private network" });
       }
       targetUrl = url.replace(/\/$/, "");
@@ -3919,7 +3919,7 @@ export const createAdminRouter = ({ toolRegistry, sidecarManager, localServerMan
       if (!/^https?:\/\/.+/.test(url)) {
         return res.status(400).json({ error: "url must be a valid HTTP(S) URL" });
       }
-      if (!isAllowedWebhookUrl(url)) {
+      if (!isAllowedNetworkNodeUrl(url)) {
         return res.status(400).json({ error: "URL points to a blocked internal/private network" });
       }
       targetUrl = url.replace(/\/$/, "");
@@ -4018,7 +4018,7 @@ export const createAdminRouter = ({ toolRegistry, sidecarManager, localServerMan
       if (!/^https?:\/\/.+/.test(url)) {
         return res.status(400).json({ error: "url must be a valid HTTP(S) URL" });
       }
-      if (!isAllowedWebhookUrl(url)) {
+      if (!isAllowedNetworkNodeUrl(url)) {
         return res.status(400).json({ error: "URL points to a blocked internal/private network" });
       }
       targetUrl = url.replace(/\/$/, "");

--- a/src/security/url-validation.ts
+++ b/src/security/url-validation.ts
@@ -39,3 +39,38 @@ export function isAllowedWebhookUrl(urlString: string): boolean {
 
   return true;
 }
+
+/**
+ * Validate a user-configured network node URL (image-gen, video-gen, music-gen workers).
+ * Less restrictive than isAllowedWebhookUrl — permits private LAN IPs since these are
+ * admin-configured worker nodes on the user's own network. Still blocks metadata
+ * endpoints, loopback addresses, and non-HTTP protocols to prevent accidental SSRF.
+ */
+export function isAllowedNetworkNodeUrl(urlString: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(urlString);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
+
+  const hostname = parsed.hostname.toLowerCase();
+
+  // Block loopback and unspecified
+  if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]") return false;
+  if (hostname === "0.0.0.0") return false;
+
+  // Block cloud metadata endpoints
+  if (hostname === "169.254.169.254" || hostname === "metadata.google.internal") return false;
+  if (hostname.startsWith("169.254.")) return false;
+
+  // Block IPv6 link-local/unique-local
+  if (hostname.startsWith("[fe80:") || hostname.startsWith("[fc") || hostname.startsWith("[fd"))
+    return false;
+
+  // Private LAN IPs (10.x, 192.168.x, 172.16-31.x) are allowed — these are legitimate worker nodes.
+
+  return true;
+}


### PR DESCRIPTION
## Problem
The SSRF guard added in #587 (\) was incorrectly applied to the admin panel's 'Test Connection' endpoints for image-gen, video-gen, and music-gen network nodes. This blocked legitimate LAN worker nodes at private IP ranges (e.g. `192.168.x.x`).

## Fix
Added \ to \ — a purpose-specific validator that:
- ✅ Allows private RFC-1918 ranges (10.x, 192.168.x, 172.16-31.x) — these are legitimate worker nodes
- ✅ Still blocks cloud metadata endpoints (169.254.169.254, metadata.google.internal)
- ✅ Still blocks loopback (localhost, 127.0.0.1, ::1) and unspecified (0.0.0.0)
- ✅ Still enforces http/https only

Used in all three health check endpoints: image-gen, video-gen, music-gen.

\ (strict, no private IPs) is still used for webhooks and blog extraction where URLs come from untrusted sources.