### PR TITLE
chore: Bump @modelcontextprotocol/sdk to v1.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgraded `@modelcontextprotocol/sdk` from v1.27.1 to v1.28.0 (latest v1 release) (#333)
+
 ### Added
 
 - Windows named pipe Docker socket detection (`//./pipe/docker_engine`) for Docker Desktop on Windows (#598)

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@google-cloud/text-to-speech": "^6.4.0",
     "@huggingface/transformers": "^3.8.1",
     "@lancedb/lancedb": "^0.26.2",
-    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@modelcontextprotocol/sdk": "^1.28.0",
     "@napi-rs/canvas": "^0.1.95",
     "@remotion/bundler": "^4.0.431",
     "@remotion/cli": "^4.0.431",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^0.26.2
         version: 0.26.2(apache-arrow@18.1.0)
       '@modelcontextprotocol/sdk':
-        specifier: ^1.27.1
-        version: 1.27.1(zod@3.25.76)
+        specifier: ^1.28.0
+        version: 1.28.0(zod@3.25.76)
       '@napi-rs/canvas':
         specifier: ^0.1.95
         version: 0.1.95
@@ -1655,8 +1655,8 @@ packages:
   '@mermaid-js/parser@1.0.0':
     resolution: {integrity: sha512-vvK0Hi/VWndxoh03Mmz6wa1KDriSPjS2XMZL/1l19HFwygiObEEoEwSDxOqyLzzAI6J2PU3261JjTMTO7x+BPw==}
 
-  '@modelcontextprotocol/sdk@1.27.1':
-    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+  '@modelcontextprotocol/sdk@1.28.0':
+    resolution: {integrity: sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -10306,7 +10306,7 @@ snapshots:
     dependencies:
       langium: 4.2.1
 
-  '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.28.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.11(hono@4.12.8)
       ajv: 8.18.0


### PR DESCRIPTION
## Summary

Minor patch bump of `@modelcontextprotocol/sdk` from `^1.27.1` to `^1.28.0`.

### Context

Epic #333 described a large migration from SDK v0.4.0 to v2. Investigation revealed that:

1. **Phase 1 (0.4.0 → 1.27.1) was already completed** in commit `9cf8ea9` ("open-source preparation and Windows support", Mar 16) — the SDK maintained full backwards compatibility so no source code changes were needed
2. **Phase 2 (v2 package split) is blocked** — the split packages (`@modelcontextprotocol/server`, `/client`, `/core`) are not yet published on npm (all return 404 as of Mar 30, 2026)

This PR completes the remaining work: bumping to the latest monolith release (1.28.0).

### Changes

- `package.json`: `@modelcontextprotocol/sdk` `^1.27.1` → `^1.28.0`
- `pnpm-lock.yaml`: Updated lockfile
- `CHANGELOG.md`: Added entry under Unreleased

### Verification

- All 5158 tests pass
- Typecheck clean
- Lint clean
- UI build clean
- All 5 CI jobs green

Closes #333