### PR TITLE
feat: Add IPC bridge for enriched backend health status → system tray indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Enriched `/health` endpoint response with `uptime` (seconds) and `memoryMB` (RSS in MB) fields (#607)
+- `backend:getHealth` IPC handler returns enriched health data to the Electron renderer (#607)
+- `window.openzigs.isElectron` flag in preload for runtime Electron detection (#607)
+- `window.openzigs.backend.getHealth()` IPC method exposes backend health data to the UI (#607)
+- Tray tooltip shows uptime and memory when backend is running (e.g., "OpenZigs — running (2h 15m, 120MB)") (#607)
+
+### Changed
+
+- `BackendManager.checkHealth()` now stores enriched health JSON (status, uptime, memoryMB) from the backend (#607)
+
 ### Changed
 
 - Sentinel autonomous monitor is now **enabled by default** — new installations start with Sentinel active; set `sentinel.enabled: false` in config to disable (#217)

--- a/desktop/src/backend.test.ts
+++ b/desktop/src/backend.test.ts
@@ -25,6 +25,7 @@ describe("BackendManager", () => {
   it("initializes with stopped status", () => {
     expect(manager.getStatus()).toBe("stopped");
     expect(manager.getPort()).toBeNull();
+    expect(manager.getHealthData()).toBeNull();
   });
 
   it("finds a free port", async () => {
@@ -45,7 +46,7 @@ describe("BackendManager", () => {
     // Start a tiny HTTP server that responds like the real health endpoint
     const server = http.createServer((_req, res) => {
       res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ status: "ok" }));
+      res.end(JSON.stringify({ status: "ok", uptime: 42.5, memoryMB: 128.75 }));
     });
 
     const port = await manager.findFreePort();
@@ -54,6 +55,24 @@ describe("BackendManager", () => {
     try {
       const healthy = await manager.checkHealth(port);
       expect(healthy).toBe(true);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("stores enriched health data after successful checkHealth", async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ status: "ok", uptime: 100.0, memoryMB: 256.5 }));
+    });
+
+    const port = await manager.findFreePort();
+    await new Promise<void>((resolve) => server.listen(port, "127.0.0.1", resolve));
+
+    try {
+      await manager.checkHealth(port);
+      const data = manager.getHealthData();
+      expect(data).toEqual({ status: "ok", uptime: 100.0, memoryMB: 256.5 });
     } finally {
       server.close();
     }
@@ -96,7 +115,7 @@ describe("BackendManager", () => {
   it("start() in dev mode detects running server", async () => {
     const server = http.createServer((_req, res) => {
       res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ status: "ok" }));
+      res.end(JSON.stringify({ status: "ok", uptime: 10.0, memoryMB: 64.0 }));
     });
 
     const port = await manager.findFreePort();

--- a/desktop/src/backend.ts
+++ b/desktop/src/backend.ts
@@ -5,6 +5,12 @@ import http from "node:http";
 
 export type BackendStatus = "starting" | "running" | "stopped" | "error";
 
+export interface HealthData {
+  status: string;
+  uptime: number;
+  memoryMB: number;
+}
+
 export interface BackendManagerOptions {
   isDev: boolean;
   backendPath: string;
@@ -18,6 +24,7 @@ export class BackendManager extends EventEmitter {
   private port: number | null = null;
   private status: BackendStatus = "stopped";
   private healthInterval: ReturnType<typeof setInterval> | null = null;
+  private lastHealthData: HealthData | null = null;
   private readonly isDev: boolean;
   private readonly backendPath: string;
   private readonly healthCheckIntervalMs: number;
@@ -109,6 +116,7 @@ export class BackendManager extends EventEmitter {
       this.child.on("exit", () => clearTimeout(forceKillTimer));
       this.child = null;
     }
+    this.lastHealthData = null;
     this.setStatus("stopped");
   }
 
@@ -118,6 +126,10 @@ export class BackendManager extends EventEmitter {
 
   getStatus(): BackendStatus {
     return this.status;
+  }
+
+  getHealthData(): HealthData | null {
+    return this.lastHealthData;
   }
 
   private setStatus(status: BackendStatus): void {
@@ -148,8 +160,17 @@ export class BackendManager extends EventEmitter {
           });
           res.on("end", () => {
             try {
-              const json = JSON.parse(body) as { status?: string };
-              resolve(json.status === "ok");
+              const json = JSON.parse(body) as Record<string, unknown>;
+              if (json.status === "ok") {
+                this.lastHealthData = {
+                  status: String(json.status),
+                  uptime: typeof json.uptime === "number" ? json.uptime : 0,
+                  memoryMB: typeof json.memoryMB === "number" ? json.memoryMB : 0,
+                };
+                resolve(true);
+              } else {
+                resolve(false);
+              }
             } catch {
               resolve(false);
             }

--- a/desktop/src/ipc.ts
+++ b/desktop/src/ipc.ts
@@ -43,6 +43,10 @@ export class IpcBridge {
       this.backendManager.stop();
     });
 
+    ipcMain.handle("backend:getHealth", () => {
+      return this.backendManager.getHealthData();
+    });
+
     // Forward status changes to renderer
     this.backendManager.on("status", (status) => {
       const win = this.windowManager.getWindow();

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -45,6 +45,7 @@ app.whenReady().then(async () => {
       backendManager.stop();
       app.quit();
     },
+    getHealthData: () => backendManager.getHealthData(),
   });
 
   // Initialize IPC bridge

--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -9,10 +9,19 @@ export interface UpdateState {
   error?: string;
 }
 
+export interface HealthData {
+  status: string;
+  uptime: number;
+  memoryMB: number;
+}
+
 contextBridge.exposeInMainWorld("openzigs", {
+  isElectron: true,
+
   backend: {
     getStatus: (): Promise<BackendStatus> => ipcRenderer.invoke("backend:getStatus"),
     getPort: (): Promise<number | null> => ipcRenderer.invoke("backend:getPort"),
+    getHealth: (): Promise<HealthData | null> => ipcRenderer.invoke("backend:getHealth"),
     start: (): Promise<void> => ipcRenderer.invoke("backend:start"),
     stop: (): Promise<void> => ipcRenderer.invoke("backend:stop"),
     onStatusChanged: (callback: (status: BackendStatus) => void): (() => void) => {

--- a/desktop/src/tray.ts
+++ b/desktop/src/tray.ts
@@ -1,11 +1,12 @@
 import { Tray, Menu, nativeImage } from "electron";
-import type { BackendStatus } from "./backend.js";
+import type { BackendStatus, HealthData } from "./backend.js";
 
 export interface TrayManagerOptions {
   onShowWindow: () => void;
   onStartServer: () => void;
   onStopServer: () => void;
   onQuit: () => void;
+  getHealthData?: () => HealthData | null;
 }
 
 // Simple 16x16 colored circle icons as base64 data URLs
@@ -72,7 +73,21 @@ export class TrayManager {
       icon.setTemplateImage(true);
     }
     this.tray.setImage(icon);
-    this.tray.setToolTip(`OpenZigs — ${this.currentStatus}`);
+    this.tray.setToolTip(this.buildTooltip());
+  }
+
+  private buildTooltip(): string {
+    const base = `OpenZigs — ${this.currentStatus}`;
+    if (this.currentStatus !== "running") return base;
+
+    const health = this.callbacks.getHealthData?.();
+    if (!health) return base;
+
+    const hrs = Math.floor(health.uptime / 3600);
+    const mins = Math.floor((health.uptime % 3600) / 60);
+    const uptimeStr = hrs > 0 ? `${hrs}h ${mins}m` : `${mins}m`;
+    const memStr = `${Math.round(health.memoryMB)}MB`;
+    return `${base} (${uptimeStr}, ${memStr})`;
   }
 
   private updateContextMenu(): void {

--- a/src/health.test.ts
+++ b/src/health.test.ts
@@ -3,6 +3,22 @@ import { getHealth } from "./health.js";
 
 describe("getHealth", () => {
   it("returns ok status", () => {
-    expect(getHealth()).toEqual({ status: "ok" });
+    const result = getHealth();
+    expect(result.status).toBe("ok");
+  });
+
+  it("includes uptime as a non-negative number", () => {
+    const result = getHealth();
+    expect(result.uptime).toBeTypeOf("number");
+    expect(result.uptime).toBeGreaterThanOrEqual(0);
+  });
+
+  it("includes memoryMB as a positive number rounded to 2 decimal places", () => {
+    const result = getHealth();
+    expect(result.memoryMB).toBeTypeOf("number");
+    expect(result.memoryMB).toBeGreaterThan(0);
+    // Verify rounding to 2 decimal places
+    const decimalStr = String(result.memoryMB).split(".")[1] ?? "";
+    expect(decimalStr.length).toBeLessThanOrEqual(2);
   });
 });

--- a/src/health.ts
+++ b/src/health.ts
@@ -1,5 +1,11 @@
 export type HealthStatus = {
   status: "ok";
+  uptime: number;
+  memoryMB: number;
 };
 
-export const getHealth = (): HealthStatus => ({ status: "ok" });
+export const getHealth = (): HealthStatus => ({
+  status: "ok",
+  uptime: process.uptime(),
+  memoryMB: Math.round((process.memoryUsage().rss / (1024 * 1024)) * 100) / 100,
+});


### PR DESCRIPTION
## Summary

Adds an enriched health data pipeline from the backend `/health` endpoint through the Electron main process IPC bridge to the renderer, fulfilling the requirements for issue #607.

## Changes

### 1. Enriched `/health` endpoint (`src/health.ts`)
- Added `uptime` (seconds via `process.uptime()`) and `memoryMB` (RSS rounded to 2 decimal places) fields
- Backward-compatible: `status: "ok"` field preserved

### 2. BackendManager enriched health storage (`desktop/src/backend.ts`)
- Added `HealthData` interface (`status`, `uptime`, `memoryMB`)
- `checkHealth()` now parses and stores the full enriched JSON in `lastHealthData`
- Added `getHealthData()` public getter
- `stop()` clears stored health data

### 3. IPC handler (`desktop/src/ipc.ts`)
- Added `backend:getHealth` handler that returns `backendManager.getHealthData()`

### 4. Preload (`desktop/src/preload.ts`)
- Added `isElectron: true` at the `window.openzigs` level
- Added `backend.getHealth()` → `ipcRenderer.invoke("backend:getHealth")`

### 5. Tray tooltip (`desktop/src/tray.ts`)
- Enriched tooltip when running: "OpenZigs — running (2h 15m, 120MB)"
- Added optional `getHealthData` callback in `TrayManagerOptions`
- Wired in `main.ts`

### Note on `activeSessions`
Skipped for now — exposing a session count would require injecting the session store into the health endpoint. Can be added later when the session manager exposes a count API.

## Tests
- Updated `src/health.test.ts` with assertions for `uptime` and `memoryMB`
- Updated `desktop/src/backend.test.ts` with enriched health response mocks and `getHealthData()` verification
- All 257 test files pass (5177 tests)

## Quality Gate
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅ (257 files, 5177 tests)
- `cd desktop && npx tsc --noEmit` ✅

Closes #607