### PR TITLE
feat: Resolve #690 — Persist Webhook Configs to SQLite

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,4 +47,4 @@
 - Always-on tools (`read-file`, `list-directory`, `web-search`, `browser-navigate`, `shell-execute`, `spawn-agent`, `orchestrate-agents`) are always included regardless of tool limit filtering.
 - Logging: Winston logger + `AuditLogger` with JSONL persistence at `~/.openzigs/logs/`, value redaction, categories: `session`, `message`, `tool`, `security`, `system`.
 - Sentinel state persists to `~/.openzigs/sentinel/`; uses atomic write-to-temp-then-rename for state files.
-- Webhook configs in [src/webhooks/webhook-manager.ts](src/webhooks/webhook-manager.ts) are currently in-memory (non-persistent across restart); treat as an MVP limitation when debugging webhook behavior.
+- Webhook configs are persisted to SQLite via [src/webhooks/webhook-repository.ts](src/webhooks/webhook-repository.ts) (WAL mode). Rate-limit state is intentionally in-memory (resets on restart).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Webhook configurations are now persisted to SQLite (`webhooks` table) and survive server restarts (#690)
+- New `WebhookRepository` class providing SQLite-backed CRUD for webhook configs (#692)
+
+### Changed
+
+- `WebhookManager` now delegates all storage to `WebhookRepository` instead of an in-memory `Map` (#694)
+- Rate-limit state remains intentionally in-memory (resets on restart) (#690)
+
+### Added
+
 - Enriched `/health` endpoint response with `uptime` (seconds) and `memoryMB` (RSS in MB) fields (#607)
 - `backend:getHealth` IPC handler returns enriched health data to the Electron renderer (#607)
 - `window.openzigs.isElectron` flag in preload for runtime Electron detection (#607)

--- a/src/productivity/database.ts
+++ b/src/productivity/database.ts
@@ -9,6 +9,7 @@ import { BrandVoiceRepository } from "../personality/brand-voice-repository.js";
 import { CharacterRepository } from "../characters/character-repository.js";
 import { PinterestTrackerRepository } from "../mcp/tools/pinterest-tracker.js";
 import { OutboxRepository } from "../outbox/outbox-repository.js";
+import { WebhookRepository } from "../webhooks/webhook-repository.js";
 import { YouTubePublishRepository } from "../video/youtube-publish-repository.js";
 import { BrandKitRepository } from "../video/brand-kit.js";
 
@@ -69,6 +70,10 @@ export const getDatabase = (options: DatabaseOptions = {}): Database.Database =>
   // Run Brand Kit migration (brand_kits table)
   const brandKitRepo = new BrandKitRepository(db);
   brandKitRepo.migrate();
+
+  // Run Webhook migration (webhooks table)
+  const webhookRepo = new WebhookRepository(db);
+  webhookRepo.migrate();
 
   sharedDb = db;
   return db;

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,6 +36,7 @@ import { launchChrome, killChrome } from "./browser/chrome-launcher.js";
 import { TaskRepository, TaskEngine, TaskWorker, NotificationDispatcher, TaskEventStreamer, ResultInjector } from "./tasks/index.js";
 import { getDatabase, closeDatabase } from "./productivity/database.js";
 import { WebhookManager } from "./webhooks/webhook-manager.js";
+import { WebhookRepository } from "./webhooks/webhook-repository.js";
 import { createWebhookRouter } from "./webhooks/webhook-routes.js";
 import { PromptManager } from "./productivity/prompt-manager.js";
 import { Scheduler } from "./productivity/scheduler.js";
@@ -807,8 +808,10 @@ const sentinel = new SentinelService({
   knowledgeService,
 });
 
-// ── Webhook Manager ──
-const webhookManager = new WebhookManager();
+// ── Webhook Manager (SQLite-backed) ──
+const webhookRepo = new WebhookRepository(db);
+webhookRepo.migrate();
+const webhookManager = new WebhookManager(webhookRepo);
 
 // Model API routes
 const modelsRouter = createModelsRouter({ copilot });

--- a/src/webhooks/webhook-manager.test.ts
+++ b/src/webhooks/webhook-manager.test.ts
@@ -1,12 +1,24 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { createHmac } from "node:crypto";
+import Database from "better-sqlite3";
 import { WebhookManager } from "./webhook-manager.js";
+import { WebhookRepository } from "./webhook-repository.js";
+
+const createTestDb = () => {
+  const db = new Database(":memory:");
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+  return db;
+};
 
 describe("WebhookManager", () => {
   let manager: WebhookManager;
 
   beforeEach(() => {
-    manager = new WebhookManager();
+    const db = createTestDb();
+    const repo = new WebhookRepository(db);
+    repo.migrate();
+    manager = new WebhookManager(repo);
   });
 
   it("creates a webhook with API key", () => {

--- a/src/webhooks/webhook-manager.ts
+++ b/src/webhooks/webhook-manager.ts
@@ -1,5 +1,6 @@
 import { randomBytes, createHmac, timingSafeEqual, scryptSync } from "node:crypto";
 import { nanoid } from "nanoid";
+import type { WebhookRepository } from "./webhook-repository.js";
 
 /* ── Types ── */
 
@@ -42,15 +43,22 @@ export type WebhookEvent = {
 };
 
 /**
- * In-memory webhook manager with JSON file persistence.
+ * SQLite-backed webhook manager.
  *
- * Production note: For real enterprise deployments, replace this with
- * a proper database (SQLite, Postgres) — the in-memory approach keeps
- * things simple for the initial MVP.
+ * All webhook configuration is persisted through `WebhookRepository`.
+ * Rate-limit state is intentionally kept in-memory (ephemeral by design —
+ * counters reset on restart, which is the safe default).
  */
 export class WebhookManager {
-  private webhooks = new Map<string, WebhookConfig>();
+  private repo: WebhookRepository;
+  private clock: () => Date;
+  /** In-memory rate-limit counters — intentionally ephemeral. */
   private rateCounts = new Map<string, { count: number; windowStart: number }>();
+
+  constructor(repo: WebhookRepository, clock?: () => Date) {
+    this.repo = repo;
+    this.clock = clock ?? (() => new Date());
+  }
 
   /** Create a new webhook and return it with the plaintext API key (shown once). */
   create(input: CreateWebhookInput): { webhook: WebhookConfig; apiKey: string } {
@@ -59,6 +67,7 @@ export class WebhookManager {
     const salt = randomBytes(16).toString("hex");
     const apiKeyHash = this.hashKey(apiKey, salt);
     const secret = randomBytes(32).toString("hex");
+    const now = this.clock().toISOString();
 
     const webhook: WebhookConfig = {
       id,
@@ -71,49 +80,46 @@ export class WebhookManager {
       enabled: true,
       allowedIps: input.allowedIps ?? [],
       rateLimit: input.rateLimit ?? 60,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
+      createdAt: now,
+      updatedAt: now,
       lastTriggeredAt: null,
       triggerCount: 0,
     };
 
-    this.webhooks.set(id, webhook);
+    this.repo.insert(webhook);
     return { webhook, apiKey };
   }
 
   /** List all webhooks (secrets are included — filter for external display). */
   list(): WebhookConfig[] {
-    return [...this.webhooks.values()];
+    return this.repo.list();
   }
 
   /** Get a single webhook by ID. */
   get(id: string): WebhookConfig | undefined {
-    return this.webhooks.get(id);
+    return this.repo.getById(id);
   }
 
   /** Toggle enabled state. */
   toggle(id: string, enabled: boolean): WebhookConfig | undefined {
-    const wh = this.webhooks.get(id);
-    if (!wh) return undefined;
-    wh.enabled = enabled;
-    wh.updatedAt = new Date().toISOString();
-    return wh;
+    return this.repo.update(id, { enabled });
   }
 
   /** Delete a webhook. */
   delete(id: string): boolean {
-    return this.webhooks.delete(id);
+    return this.repo.deleteById(id);
   }
 
   /** Rotate the API key — returns new plaintext key. */
   rotateKey(id: string): { apiKey: string } | undefined {
-    const wh = this.webhooks.get(id);
+    const wh = this.repo.getById(id);
     if (!wh) return undefined;
     const apiKey = `whk_${randomBytes(24).toString("hex")}`;
     const salt = randomBytes(16).toString("hex");
-    wh.apiKeySalt = salt;
-    wh.apiKeyHash = this.hashKey(apiKey, salt);
-    wh.updatedAt = new Date().toISOString();
+    this.repo.update(id, {
+      apiKeySalt: salt,
+      apiKeyHash: this.hashKey(apiKey, salt),
+    });
     return { apiKey };
   }
 
@@ -121,7 +127,8 @@ export class WebhookManager {
 
   /** Authenticate a request by API key (Bearer token). Returns the webhook or undefined. */
   authenticateByApiKey(apiKey: string): WebhookConfig | undefined {
-    for (const wh of this.webhooks.values()) {
+    const all = this.repo.list();
+    for (const wh of all) {
       const hash = this.hashKey(apiKey, wh.apiKeySalt);
       if (this.safeCompare(hash, wh.apiKeyHash)) {
         return wh;
@@ -132,7 +139,7 @@ export class WebhookManager {
 
   /** Verify an HMAC-SHA256 signature. */
   verifySignature(webhookId: string, body: string, signature: string): boolean {
-    const wh = this.webhooks.get(webhookId);
+    const wh = this.repo.getById(webhookId);
     if (!wh) return false;
 
     const expected = createHmac("sha256", wh.secret)
@@ -146,11 +153,11 @@ export class WebhookManager {
     }
   }
 
-  /* ── Rate Limiting ── */
+  /* ── Rate Limiting (in-memory — intentionally ephemeral) ── */
 
   /** Check (and consume) a rate-limit slot. Returns true if allowed. */
   checkRateLimit(webhookId: string): boolean {
-    const wh = this.webhooks.get(webhookId);
+    const wh = this.repo.getById(webhookId);
     if (!wh || wh.rateLimit === 0) return true;
 
     const now = Date.now();
@@ -166,11 +173,12 @@ export class WebhookManager {
 
   /** Record a successful trigger. */
   recordTrigger(webhookId: string): void {
-    const wh = this.webhooks.get(webhookId);
+    const wh = this.repo.getById(webhookId);
     if (!wh) return;
-    wh.triggerCount += 1;
-    wh.lastTriggeredAt = new Date().toISOString();
-    wh.updatedAt = new Date().toISOString();
+    this.repo.update(webhookId, {
+      triggerCount: wh.triggerCount + 1,
+      lastTriggeredAt: this.clock().toISOString(),
+    });
   }
 
   /* ── Helpers ── */

--- a/src/webhooks/webhook-repository.test.ts
+++ b/src/webhooks/webhook-repository.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+import { WebhookRepository } from "./webhook-repository.js";
+import type { WebhookConfig } from "./webhook-manager.js";
+
+const createTestDb = () => {
+  const db = new Database(":memory:");
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+  return db;
+};
+
+const makeConfig = (overrides: Partial<WebhookConfig> = {}): WebhookConfig => ({
+  id: "wh_test_1",
+  name: "Test Hook",
+  action: "prompt",
+  actionPayload: { promptName: "daily-summary" },
+  secret: "deadbeef",
+  apiKeyHash: "hash123",
+  apiKeySalt: "salt123",
+  enabled: true,
+  allowedIps: ["10.0.0.1"],
+  rateLimit: 60,
+  createdAt: "2026-03-31T00:00:00.000Z",
+  updatedAt: "2026-03-31T00:00:00.000Z",
+  lastTriggeredAt: null,
+  triggerCount: 0,
+  ...overrides,
+});
+
+describe("WebhookRepository", () => {
+  let db: Database.Database;
+  let repo: WebhookRepository;
+  const now = new Date("2026-03-31T12:00:00Z");
+  const clock = () => now;
+
+  beforeEach(() => {
+    db = createTestDb();
+    repo = new WebhookRepository(db, clock);
+    repo.migrate();
+  });
+
+  // ── Schema ──
+
+  describe("migrate", () => {
+    it("creates the webhooks table", () => {
+      const tables = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='webhooks'")
+        .all();
+      expect(tables).toHaveLength(1);
+    });
+
+    it("is idempotent — can be called multiple times", () => {
+      repo.migrate();
+      repo.migrate();
+      const tables = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='webhooks'")
+        .all();
+      expect(tables).toHaveLength(1);
+    });
+  });
+
+  // ── Insert + getById ──
+
+  describe("insert + getById", () => {
+    it("inserts and retrieves a webhook by ID", () => {
+      const config = makeConfig();
+      repo.insert(config);
+      const retrieved = repo.getById("wh_test_1");
+      expect(retrieved).toBeDefined();
+      expect(retrieved!.id).toBe("wh_test_1");
+      expect(retrieved!.name).toBe("Test Hook");
+      expect(retrieved!.action).toBe("prompt");
+      expect(retrieved!.actionPayload).toEqual({ promptName: "daily-summary" });
+      expect(retrieved!.secret).toBe("deadbeef");
+      expect(retrieved!.apiKeyHash).toBe("hash123");
+      expect(retrieved!.apiKeySalt).toBe("salt123");
+      expect(retrieved!.enabled).toBe(true);
+      expect(retrieved!.allowedIps).toEqual(["10.0.0.1"]);
+      expect(retrieved!.rateLimit).toBe(60);
+      expect(retrieved!.triggerCount).toBe(0);
+      expect(retrieved!.lastTriggeredAt).toBeNull();
+    });
+
+    it("returns undefined for nonexistent ID", () => {
+      expect(repo.getById("nonexistent")).toBeUndefined();
+    });
+
+    it("stores and retrieves the goal action type", () => {
+      const config = makeConfig({ id: "wh_goal", action: "goal", actionPayload: { goal: "run report" } });
+      repo.insert(config);
+      const retrieved = repo.getById("wh_goal");
+      expect(retrieved!.action).toBe("goal");
+      expect(retrieved!.actionPayload).toEqual({ goal: "run report" });
+    });
+
+    it("handles empty allowedIps array", () => {
+      const config = makeConfig({ id: "wh_empty_ips", allowedIps: [] });
+      repo.insert(config);
+      const retrieved = repo.getById("wh_empty_ips");
+      expect(retrieved!.allowedIps).toEqual([]);
+    });
+
+    it("handles a webhook with lastTriggeredAt set", () => {
+      const config = makeConfig({ id: "wh_triggered", lastTriggeredAt: "2026-03-31T06:00:00.000Z", triggerCount: 5 });
+      repo.insert(config);
+      const retrieved = repo.getById("wh_triggered");
+      expect(retrieved!.lastTriggeredAt).toBe("2026-03-31T06:00:00.000Z");
+      expect(retrieved!.triggerCount).toBe(5);
+    });
+  });
+
+  // ── List ──
+
+  describe("list", () => {
+    it("returns empty array when no webhooks exist", () => {
+      expect(repo.list()).toEqual([]);
+    });
+
+    it("returns all webhooks ordered by created_at DESC", () => {
+      repo.insert(makeConfig({ id: "wh_a", name: "Alpha", createdAt: "2026-03-30T00:00:00.000Z" }));
+      repo.insert(makeConfig({ id: "wh_b", name: "Beta", createdAt: "2026-03-31T00:00:00.000Z" }));
+      const list = repo.list();
+      expect(list).toHaveLength(2);
+      expect(list[0].name).toBe("Beta");
+      expect(list[1].name).toBe("Alpha");
+    });
+  });
+
+  // ── Update ──
+
+  describe("update", () => {
+    it("updates the enabled flag", () => {
+      repo.insert(makeConfig());
+      const updated = repo.update("wh_test_1", { enabled: false });
+      expect(updated!.enabled).toBe(false);
+      expect(updated!.updatedAt).toBe("2026-03-31T12:00:00.000Z");
+    });
+
+    it("updates name", () => {
+      repo.insert(makeConfig());
+      const updated = repo.update("wh_test_1", { name: "New Name" });
+      expect(updated!.name).toBe("New Name");
+    });
+
+    it("updates apiKeyHash and apiKeySalt", () => {
+      repo.insert(makeConfig());
+      const updated = repo.update("wh_test_1", { apiKeyHash: "newhash", apiKeySalt: "newsalt" });
+      expect(updated!.apiKeyHash).toBe("newhash");
+      expect(updated!.apiKeySalt).toBe("newsalt");
+    });
+
+    it("updates triggerCount and lastTriggeredAt", () => {
+      repo.insert(makeConfig());
+      const updated = repo.update("wh_test_1", { triggerCount: 42, lastTriggeredAt: "2026-03-31T11:00:00.000Z" });
+      expect(updated!.triggerCount).toBe(42);
+      expect(updated!.lastTriggeredAt).toBe("2026-03-31T11:00:00.000Z");
+    });
+
+    it("updates allowedIps", () => {
+      repo.insert(makeConfig());
+      const updated = repo.update("wh_test_1", { allowedIps: ["192.168.1.0/24"] });
+      expect(updated!.allowedIps).toEqual(["192.168.1.0/24"]);
+    });
+
+    it("updates rateLimit", () => {
+      repo.insert(makeConfig());
+      const updated = repo.update("wh_test_1", { rateLimit: 120 });
+      expect(updated!.rateLimit).toBe(120);
+    });
+
+    it("returns undefined for nonexistent ID", () => {
+      expect(repo.update("nonexistent", { enabled: false })).toBeUndefined();
+    });
+  });
+
+  // ── Delete ──
+
+  describe("deleteById", () => {
+    it("deletes an existing webhook and returns true", () => {
+      repo.insert(makeConfig());
+      expect(repo.deleteById("wh_test_1")).toBe(true);
+      expect(repo.getById("wh_test_1")).toBeUndefined();
+    });
+
+    it("returns false for nonexistent ID", () => {
+      expect(repo.deleteById("nonexistent")).toBe(false);
+    });
+
+    it("does not affect other webhooks", () => {
+      repo.insert(makeConfig({ id: "wh_a", name: "A" }));
+      repo.insert(makeConfig({ id: "wh_b", name: "B" }));
+      repo.deleteById("wh_a");
+      expect(repo.list()).toHaveLength(1);
+      expect(repo.list()[0].name).toBe("B");
+    });
+  });
+
+  // ── Persistence across new repo instance ──
+
+  describe("persistence", () => {
+    it("data survives a new WebhookRepository instance on the same db", () => {
+      repo.insert(makeConfig({ id: "wh_persist" }));
+      const repo2 = new WebhookRepository(db, clock);
+      // No need to re-migrate — table already exists
+      const retrieved = repo2.getById("wh_persist");
+      expect(retrieved).toBeDefined();
+      expect(retrieved!.id).toBe("wh_persist");
+    });
+  });
+
+  // ── Clock injection ──
+
+  describe("clock injection", () => {
+    it("uses injected clock for updated_at on update", () => {
+      const customClock = () => new Date("2099-12-31T23:59:59.000Z");
+      const clockedRepo = new WebhookRepository(db, customClock);
+      clockedRepo.migrate();
+      clockedRepo.insert(makeConfig({ id: "wh_clock" }));
+      const updated = clockedRepo.update("wh_clock", { name: "Clocked" });
+      expect(updated!.updatedAt).toBe("2099-12-31T23:59:59.000Z");
+    });
+  });
+
+  // ── Edge cases ──
+
+  describe("edge cases", () => {
+    it("stores complex actionPayload with nested objects", () => {
+      const payload = { promptName: "test", vars: { a: 1, b: [2, 3] }, deep: { nested: true } };
+      repo.insert(makeConfig({ id: "wh_complex", actionPayload: payload }));
+      const retrieved = repo.getById("wh_complex");
+      expect(retrieved!.actionPayload).toEqual(payload);
+    });
+
+    it("stores multiple allowed IPs", () => {
+      const ips = ["10.0.0.1", "192.168.1.0/24", "172.16.0.0/12"];
+      repo.insert(makeConfig({ id: "wh_multi_ip", allowedIps: ips }));
+      const retrieved = repo.getById("wh_multi_ip");
+      expect(retrieved!.allowedIps).toEqual(ips);
+    });
+
+    it("handles rateLimit of 0 (unlimited)", () => {
+      repo.insert(makeConfig({ id: "wh_unlimited", rateLimit: 0 }));
+      const retrieved = repo.getById("wh_unlimited");
+      expect(retrieved!.rateLimit).toBe(0);
+    });
+
+    it("rejects duplicate primary key", () => {
+      repo.insert(makeConfig({ id: "wh_dup" }));
+      expect(() => repo.insert(makeConfig({ id: "wh_dup" }))).toThrow();
+    });
+  });
+});

--- a/src/webhooks/webhook-repository.ts
+++ b/src/webhooks/webhook-repository.ts
@@ -1,0 +1,148 @@
+import Database from "better-sqlite3";
+import type { WebhookConfig } from "./webhook-manager.js";
+
+/**
+ * SQLite-backed repository for webhook configurations.
+ *
+ * Follows the same pattern as `SocialRepository` — constructor accepts a
+ * `Database.Database` instance and an optional `clock` for deterministic time
+ * in tests. Call `migrate()` once at startup to ensure the schema exists.
+ */
+export class WebhookRepository {
+  private db: Database.Database;
+  private clock: () => Date;
+
+  constructor(db: Database.Database, clock?: () => Date) {
+    this.db = db;
+    this.clock = clock ?? (() => new Date());
+  }
+
+  // ── Schema ──────────────────────────────────────────────────────────
+
+  migrate(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS webhooks (
+        id                TEXT PRIMARY KEY,
+        name              TEXT NOT NULL,
+        action            TEXT NOT NULL CHECK(action IN ('prompt', 'goal')),
+        action_payload    TEXT NOT NULL DEFAULT '{}',
+        secret            TEXT NOT NULL,
+        api_key_hash      TEXT NOT NULL,
+        api_key_salt      TEXT NOT NULL,
+        enabled           INTEGER NOT NULL DEFAULT 1,
+        allowed_ips       TEXT NOT NULL DEFAULT '[]',
+        rate_limit        INTEGER NOT NULL DEFAULT 60,
+        created_at        TEXT NOT NULL,
+        updated_at        TEXT NOT NULL,
+        last_triggered_at TEXT,
+        trigger_count     INTEGER NOT NULL DEFAULT 0
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_webhooks_enabled ON webhooks(enabled);
+    `);
+  }
+
+  // ── CRUD ────────────────────────────────────────────────────────────
+
+  insert(config: WebhookConfig): void {
+    this.db
+      .prepare(
+        `INSERT INTO webhooks (id, name, action, action_payload, secret, api_key_hash,
+         api_key_salt, enabled, allowed_ips, rate_limit, created_at, updated_at,
+         last_triggered_at, trigger_count)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        config.id,
+        config.name,
+        config.action,
+        JSON.stringify(config.actionPayload),
+        config.secret,
+        config.apiKeyHash,
+        config.apiKeySalt,
+        config.enabled ? 1 : 0,
+        JSON.stringify(config.allowedIps),
+        config.rateLimit,
+        config.createdAt,
+        config.updatedAt,
+        config.lastTriggeredAt,
+        config.triggerCount,
+      );
+  }
+
+  getById(id: string): WebhookConfig | undefined {
+    const row = this.db.prepare("SELECT * FROM webhooks WHERE id = ?").get(id) as WebhookRow | undefined;
+    return row ? this.rowToConfig(row) : undefined;
+  }
+
+  list(): WebhookConfig[] {
+    const rows = this.db.prepare("SELECT * FROM webhooks ORDER BY created_at DESC").all() as WebhookRow[];
+    return rows.map((r) => this.rowToConfig(r));
+  }
+
+  update(id: string, updates: Partial<Pick<WebhookConfig, "name" | "enabled" | "allowedIps" | "rateLimit" | "apiKeyHash" | "apiKeySalt" | "lastTriggeredAt" | "triggerCount">>): WebhookConfig | undefined {
+    const existing = this.getById(id);
+    if (!existing) return undefined;
+
+    const now = this.clock().toISOString();
+    const sets: string[] = ["updated_at = ?"];
+    const params: unknown[] = [now];
+
+    if (updates.name !== undefined) { sets.push("name = ?"); params.push(updates.name); }
+    if (updates.enabled !== undefined) { sets.push("enabled = ?"); params.push(updates.enabled ? 1 : 0); }
+    if (updates.allowedIps !== undefined) { sets.push("allowed_ips = ?"); params.push(JSON.stringify(updates.allowedIps)); }
+    if (updates.rateLimit !== undefined) { sets.push("rate_limit = ?"); params.push(updates.rateLimit); }
+    if (updates.apiKeyHash !== undefined) { sets.push("api_key_hash = ?"); params.push(updates.apiKeyHash); }
+    if (updates.apiKeySalt !== undefined) { sets.push("api_key_salt = ?"); params.push(updates.apiKeySalt); }
+    if (updates.lastTriggeredAt !== undefined) { sets.push("last_triggered_at = ?"); params.push(updates.lastTriggeredAt); }
+    if (updates.triggerCount !== undefined) { sets.push("trigger_count = ?"); params.push(updates.triggerCount); }
+
+    params.push(id);
+    this.db.prepare(`UPDATE webhooks SET ${sets.join(", ")} WHERE id = ?`).run(...params);
+    return this.getById(id);
+  }
+
+  deleteById(id: string): boolean {
+    const result = this.db.prepare("DELETE FROM webhooks WHERE id = ?").run(id);
+    return result.changes > 0;
+  }
+
+  // ── Helpers ─────────────────────────────────────────────────────────
+
+  private rowToConfig(row: WebhookRow): WebhookConfig {
+    return {
+      id: row.id,
+      name: row.name,
+      action: row.action as "prompt" | "goal",
+      actionPayload: JSON.parse(row.action_payload),
+      secret: row.secret,
+      apiKeyHash: row.api_key_hash,
+      apiKeySalt: row.api_key_salt,
+      enabled: row.enabled === 1,
+      allowedIps: JSON.parse(row.allowed_ips),
+      rateLimit: row.rate_limit,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      lastTriggeredAt: row.last_triggered_at,
+      triggerCount: row.trigger_count,
+    };
+  }
+}
+
+/** Raw SQLite row shape — columns use snake_case. */
+type WebhookRow = {
+  id: string;
+  name: string;
+  action: string;
+  action_payload: string;
+  secret: string;
+  api_key_hash: string;
+  api_key_salt: string;
+  enabled: number;
+  allowed_ips: string;
+  rate_limit: number;
+  created_at: string;
+  updated_at: string;
+  last_triggered_at: string | null;
+  trigger_count: number;
+};


### PR DESCRIPTION
## Summary

Migrates `WebhookManager` from an in-memory `Map` to a SQLite-backed `WebhookRepository`, eliminating the MVP limitation where webhook configurations were lost on server restart.

## Changes

### New Files
- **`src/webhooks/webhook-repository.ts`** — SQLite-backed repository for webhook configs following the `SocialRepository` pattern (constructor accepts `Database.Database` + optional `clock`, `migrate()` for schema, full CRUD)
- **`src/webhooks/webhook-repository.test.ts`** — 25 unit tests covering schema creation, CRUD, persistence, clock injection, and edge cases (in-memory SQLite with WAL + foreign keys)

### Modified Files
- **`src/webhooks/webhook-manager.ts`** — Replaced in-memory `Map` with `WebhookRepository` delegation. Public API (`create`, `list`, `get`, `toggle`, `delete`, `rotateKey`, `authenticateByApiKey`, `verifySignature`, `checkRateLimit`, `recordTrigger`) is unchanged. Rate-limit state intentionally remains in-memory (ephemeral by design).
- **`src/webhooks/webhook-manager.test.ts`** — Updated to construct `WebhookManager` with a real in-memory SQLite `WebhookRepository`
- **`src/server.ts`** — Wire up `WebhookRepository` with the shared `db` instance, call `migrate()`, pass repo to `WebhookManager`
- **`src/productivity/database.ts`** — Register `WebhookRepository.migrate()` in the startup migration chain
- **`.github/copilot-instructions.md`** — Replaced MVP caveat with accurate description of SQLite-backed persistence
- **`CHANGELOG.md`** — Added entries under `[Unreleased]`

## Test Coverage

- **258 test files, 5202 tests passing**
- 35 webhook-specific tests (25 repository + 10 manager) all pass
- Existing webhook-auth (19 tests) and webhook-routes (10 tests) continue to pass unchanged

## Security Review

- HMAC auth + scrypt key hashing preserved unchanged
- No new external inputs or SQL injection vectors (parameterized queries throughout)
- No hardcoded secrets or credentials

Closes #690
Closes #692
Closes #694
Closes #695
Closes #693