### PR TITLE
fix(#941): harden Copilot SDK startup error path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added (Epic #941 — Harden Copilot SDK startup)
+
+- **`POST /api/admin/copilot/restart` endpoint (#944):** New admin endpoint that resets `started`/`startFailed`/`lastStartError`/`startPromise` on the `CopilotWrapper` and re-invokes `client.start()`. Returns `{ ok, started, error? }`. Lets operators recover from a transient SDK boot failure without restarting the whole server. Requires the same admin auth as the rest of `/api/admin`.
+- **`copilot.startTimeoutMs` config knob (#942):** Zod-validated number, bounds `1000…120_000`, default `10_000`. Layered through `config/default.json` → `~/.openzigs/config.json` → env, and wired into `CopilotWrapperService` via the constructor option of the same name.
+- **TaskWorker `awaiting_copilot` recovery (#945):** Background tasks that throw `Copilot SDK is unavailable` are no longer permanently failed. Instead they are deferred back to `queued` with an `awaiting_copilot_until` timestamp (`now + 30s`) via the new `TaskEngine.deferForCopilot()` and `TaskRepository.deferForCopilot()` methods. The dequeue path filters out rows whose deferred-until is in the future. Schema migration follows the existing `ALTER TABLE` pattern (new `awaiting_copilot_until TEXT` column).
+- **Copilot CLI Troubleshooting subsection in `docs/USER_GUIDE.md` (#946):** Documents (a) what the new error message means, (b) that `@github/copilot-sdk` bundles its own CLI per [github/copilot-sdk#984](https://github.com/github/copilot-sdk/issues/984), (c) the new restart endpoint, and (d) the configurable startup timeout.
+
+### Fixed (Epic #941)
+
+- **Real `client.start()` errors are now surfaced (#943):** `CopilotWrapperService.doStart()` previously swallowed the underlying error with a bare `catch {}` and `chat()`/`listModels()` returned a generic message. The catch now logs the full detail via Winston with `category: "system"`, stores a `~200 char` truncated copy on a new `lastStartError` field, and surfaces it in every user-facing error message after the literal marker `Copilot SDK is unavailable: …`. Downstream consumers (TaskWorker, future UI banners) can classify recoverable failures by checking for that marker.
+- **Removed hardcoded "CLI version 0.0.394" remediation string (#946):** The wrapper no longer instructs users to upgrade to a specific SDK-bundled CLI version (which is opaque, version-pinned by the SDK, and not user-controllable per [github/copilot-sdk#984](https://github.com/github/copilot-sdk/issues/984)). Replaced with a generic pointer to `docs/USER_GUIDE.md` and the new `/api/admin/copilot/restart` endpoint.
+
 ### Added (Epic #924 — LTX video audio, longer durations & correct LoRA training params)
 
 - **LTX-Video VRAM pooling across two GPUs (#927, WS2-A):** New env-var matrix (`LTX_POOLING_MODE`, `LTX_TRANSFORMER_DEVICE=cuda:1`, `LTX_ENCODER_DEVICE=cuda:0`, `LTX_VAE_DEVICE=cuda:0`, `LTX_POOLING_MIN_VRAM_GB=18`, `LTX_MAX_FRAMES_OVERRIDE`, `LTX_ALLOW_AUDIO`) auto-detects `torch.cuda.device_count()` + per-device `mem_get_info(i)` and shards the LTX-Video pipeline (transformer on `cuda:1`, T5 encoder + VAE on `cuda:0`) when summed VRAM is ≥ threshold. Falls back gracefully to `enable_model_cpu_offload()` on any placement error. Introduces a pooled VRAM-tier table that lifts max frames from 57 (1×12 GB) to 161 (2×12 GB) and 257 (2×24 GB). Citation in the source code points to the diffusers "Working with big models" doc (Tavily verified 2026-04-22).

--- a/config/default.json
+++ b/config/default.json
@@ -78,7 +78,8 @@
     "defaultReasoningEffort": "medium",
     "defaultWorkingDirectory": null,
     "customAgents": [],
-    "nativeMcpServers": {}
+    "nativeMcpServers": {},
+    "startTimeoutMs": 10000
   },
   "knowledge": {
     "enabled": true,

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -7718,6 +7718,44 @@ Hey {{username}}! Saw your comment on our post about "{{post_caption}}". Check y
 | Voice TTS not working | Missing Google Cloud credentials. | Set `GOOGLE_APPLICATION_CREDENTIALS` env var to your service account JSON key file path. See [Enabling Voice Features](#enabling-voice-features). |
 | Wake word not responding | Web Speech API not supported in browser. | Use Chrome, Edge, or Brave. Firefox does not support the Web Speech API. |
 
+### Copilot CLI Troubleshooting
+
+When the underlying GitHub Copilot CLI fails to start, every chat and `listModels()` call throws an error containing the literal marker `Copilot SDK is unavailable`, followed by the underlying detail (e.g. `Copilot CLI start timed out after 10000ms` or `unknown option '--headless'`). The full underlying error is also written to the server log under `category: "system"`.
+
+**(a) What the error means.** The Copilot SDK could not spawn or talk to its bundled `copilot` CLI. The most common causes are:
+- The CLI binary is missing from `node_modules/@github/copilot-sdk/...` (re-run `pnpm install`).
+- The bundled CLI is incompatible with the SDK version (re-install or update the SDK).
+- A timeout on first start because the machine was busy or offline.
+- Authentication is missing (run `pnpm setup` to complete the device-flow auth).
+
+**(b) How the SDK bundles its CLI.** Per [github/copilot-sdk#984](https://github.com/github/copilot-sdk/issues/984), `@github/copilot-sdk` ships its own copy of the `copilot` CLI inside the package and invokes it as a subprocess. This is why the user's `npm i -g @github/copilot` global install does **not** affect the SDK's behavior — only the bundled binary matters. Do not pin a specific CLI version in your own code; the SDK manages that.
+
+**(c) Restart endpoint.** After fixing the underlying problem (e.g. re-running `pnpm install`), call `POST /api/admin/copilot/restart` to reset the wrapper's `startFailed` state and re-attempt startup without restarting the whole server. Response body:
+
+```json
+{ "ok": true, "started": true }
+```
+
+On failure:
+
+```json
+{ "ok": false, "started": false, "error": "Copilot CLI start timed out after 10000ms" }
+```
+
+The endpoint requires the same admin auth as the rest of `/api/admin`. Background tasks that hit the unavailability error are deferred (not failed) — they are returned to the queue with an `awaiting_copilot_until` timestamp 30 seconds in the future and will resume automatically once the SDK is healthy again.
+
+**(d) Configurable timeout.** The first `client.start()` call has a default timeout of 10 seconds. To override, set `copilot.startTimeoutMs` in `~/.openzigs/config.json` (Zod-validated to `1000…120000`):
+
+```json
+{
+  "copilot": {
+    "startTimeoutMs": 30000
+  }
+}
+```
+
+Use a higher value on slow machines or when running inside a container with cold-start latency. Use a lower value to surface unavailability faster in CI.
+
 ## Secret Vault — Zero-Trust Credential Storage
 
 The Secret Vault provides AES-256-GCM encrypted local storage for passwords, API keys, and other credentials. Secrets are stored at `~/.openzigs/vault.enc` with `0600` permissions (owner-read/write only).

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -3409,6 +3409,28 @@ export const createAdminRouter = ({
 
   // ── Copilot SDK Sessions (Phase 1-4 of Epic #334) ──
   if (copilot) {
+    // Issue #944 — restart the Copilot SDK after a startup failure.
+    router.post("/copilot/restart", async (_req, res) => {
+      if (!copilot.restart) {
+        return res.status(501).json({
+          ok: false,
+          started: false,
+          error: "Copilot wrapper does not support restart",
+        });
+      }
+      try {
+        const result = await copilot.restart();
+        const status = result.ok ? 200 : 503;
+        return res.status(status).json(result);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        logger.error(`Copilot SDK restart failed: ${message}`);
+        return res
+          .status(500)
+          .json({ ok: false, started: false, error: message });
+      }
+    });
+
     // Phase 4: Session analytics (must be before :sessionId routes)
     router.get("/copilot-sessions/analytics", (_req, res) => {
       const analytics = copilot.getSessionAnalytics();

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -179,6 +179,8 @@ export type CopilotConfig = {
   defaultWorkingDirectory?: string | null;
   customAgents?: CustomAgentConfig[];
   nativeMcpServers?: Record<string, NativeMcpServerConfig>;
+  /** Timeout in ms for the initial Copilot SDK `client.start()` call. Default 10000. */
+  startTimeoutMs?: number;
 };
 
 export type SentinelAppConfig = {
@@ -553,6 +555,13 @@ const copilotSchema = z
     defaultWorkingDirectory: z.string().nullable().optional().default(null),
     customAgents: z.array(customAgentSchema).optional().default([]),
     nativeMcpServers: nativeMcpServersSchema.optional().default({}),
+    startTimeoutMs: z
+      .number()
+      .int()
+      .min(1000)
+      .max(120_000)
+      .optional()
+      .default(10_000),
   })
   .optional();
 

--- a/src/copilot/copilot-wrapper.test.ts
+++ b/src/copilot/copilot-wrapper.test.ts
@@ -227,12 +227,90 @@ describe("copilot wrapper", () => {
     };
     const wrapper = new CopilotWrapperService({ client });
 
-    // listModels should throw since SDK failed to start
-    await expect(wrapper.listModels()).rejects.toThrow(/failed to start/);
+    // listModels should throw with the unavailability marker so callers can classify it
+    await expect(wrapper.listModels()).rejects.toThrow(/Copilot SDK is unavailable/);
 
-    // chat should throw with a descriptive message
+    // chat should throw with a descriptive message that includes the underlying detail
     const gen = wrapper.chat("Hello");
-    await expect(gen.next()).rejects.toThrow(/SDK is unavailable/);
+    await expect(gen.next()).rejects.toThrow(/Copilot SDK is unavailable.*--headless/);
+
+    // The underlying detail must be exposed for diagnostics (#943)
+    expect(wrapper.getLastStartError()).toMatch(/--headless/);
+  });
+
+  it("does NOT include a hardcoded CLI version string in the surfaced error (#946)", async () => {
+    const client = {
+      async start() { throw new Error("ENOENT"); },
+      async createSession(_config: { tools?: unknown[]; model?: string }) { return new FakeSession(); },
+      async stop() { return [] as Error[]; },
+      async listModels() { return [{ id: "gpt-4.1" }]; },
+    };
+    const wrapper = new CopilotWrapperService({ client });
+    const gen = wrapper.chat("Hello");
+    let captured: string | undefined;
+    try { await gen.next(); } catch (e) { captured = (e as Error).message; }
+    expect(captured).toBeDefined();
+    expect(captured).not.toMatch(/0\.0\.\d+/);
+    expect(captured).toMatch(/docs\/USER_GUIDE\.md/);
+  });
+
+  it("respects a custom startTimeoutMs from constructor options (#942)", async () => {
+    const client = {
+      async start() { return new Promise<void>(() => { /* never resolves */ }); },
+      async createSession(_config: { tools?: unknown[]; model?: string }) { return new FakeSession(); },
+      async stop() { return [] as Error[]; },
+      async listModels() { return [{ id: "gpt-4.1" }]; },
+    };
+    const wrapper = new CopilotWrapperService({ client, startTimeoutMs: 50 });
+    const start = Date.now();
+    await expect(wrapper.listModels()).rejects.toThrow(/Copilot SDK is unavailable/);
+    expect(Date.now() - start).toBeLessThan(2_000);
+    expect(wrapper.getLastStartError()).toMatch(/timed out after 50ms/);
+  });
+
+  it("restart() resets state and re-attempts startup (#944)", async () => {
+    let attempts = 0;
+    const client = {
+      async start() {
+        attempts++;
+        if (attempts === 1) throw new Error("transient boot failure");
+        return undefined;
+      },
+      async createSession(_config: { tools?: unknown[]; model?: string }) { return new FakeSession(); },
+      async stop() { return [] as Error[]; },
+      async listModels() { return [{ id: "gpt-4.1" }]; },
+    };
+    const wrapper = new CopilotWrapperService({ client });
+
+    // First call fails
+    await expect(wrapper.listModels()).rejects.toThrow(/Copilot SDK is unavailable/);
+    expect(wrapper.getLastStartError()).toMatch(/transient boot failure/);
+
+    // Restart should succeed on the second start() attempt
+    const result = await wrapper.restart!();
+    expect(result.ok).toBe(true);
+    expect(result.started).toBe(true);
+    expect(result.error).toBeUndefined();
+    expect(wrapper.getLastStartError()).toBeNull();
+    expect(attempts).toBe(2);
+
+    // Subsequent listModels works
+    await expect(wrapper.listModels()).resolves.toEqual([{ id: "gpt-4.1" }]);
+  });
+
+  it("restart() returns ok=false with error detail when start() still fails", async () => {
+    const client = {
+      async start() { throw new Error("still broken"); },
+      async createSession(_config: { tools?: unknown[]; model?: string }) { return new FakeSession(); },
+      async stop() { return [] as Error[]; },
+      async listModels() { return [{ id: "gpt-4.1" }]; },
+    };
+    const wrapper = new CopilotWrapperService({ client });
+    await expect(wrapper.listModels()).rejects.toThrow();
+    const result = await wrapper.restart!();
+    expect(result.ok).toBe(false);
+    expect(result.started).toBe(false);
+    expect(result.error).toMatch(/still broken/);
   });
 
   it("sets startFailed when client.start() times out", async () => {
@@ -244,15 +322,15 @@ describe("copilot wrapper", () => {
       async stop() { return [] as Error[]; },
       async listModels() { return [{ id: "gpt-4.1" }]; }
     };
-    const wrapper = new CopilotWrapperService({ client });
+    const wrapper = new CopilotWrapperService({ client, startTimeoutMs: 100 });
 
     // listModels should throw since SDK timed out
-    await expect(wrapper.listModels()).rejects.toThrow(/failed to start/);
+    await expect(wrapper.listModels()).rejects.toThrow(/Copilot SDK is unavailable/);
 
-    // chat should throw
+    // chat should throw with the marker for downstream classification
     const gen = wrapper.chat("Hello");
-    await expect(gen.next()).rejects.toThrow(/SDK is unavailable/);
-  }, 15000);
+    await expect(gen.next()).rejects.toThrow(/Copilot SDK is unavailable/);
+  });
 
   it("caches and reuses sessions when conversationId is provided", async () => {
     const client = new FakeCopilotClient();

--- a/src/copilot/copilot-wrapper.ts
+++ b/src/copilot/copilot-wrapper.ts
@@ -723,7 +723,7 @@ export class CopilotWrapperService
     lifecycleEvents: [],
     lastUpdated: new Date().toISOString(),
   };
-  private lifecycleUnsubscribe?: () => void; // retained for future teardown
+  private lifecycleUnsubscribe?: () => void;
   readonly tokenTracker = new TokenTracker();
   private memoryContextProvider?: () => Promise<string | null>;
 

--- a/src/copilot/copilot-wrapper.ts
+++ b/src/copilot/copilot-wrapper.ts
@@ -25,6 +25,7 @@ import type {
   CompactionEvent,
 } from "./token-tracker.js";
 import { getUserSelectedModel } from "../config/user-model.js";
+import { logger } from "../logging/logger.js";
 
 export type { TokenUsage, TokenUsageEvent, CompactionEvent };
 
@@ -471,6 +472,10 @@ export interface CopilotWrapper {
   getSkillDirectories?(): string[];
   /** Add a skill directory and invalidate cached sessions. */
   addSkillDirectory?(dir: string): void;
+  /** Underlying detail of the most recent startup failure, or null if start succeeded / has not been attempted. */
+  getLastStartError?(): string | null;
+  /** Reset the start state and re-attempt SDK startup. Returns the outcome of the new attempt. */
+  restart?(): Promise<{ ok: boolean; started: boolean; error?: string }>;
 }
 
 export type CopilotWrapperOptions = {
@@ -480,6 +485,8 @@ export type CopilotWrapperOptions = {
   clientId?: string;
   model?: string;
   authTimeoutMs?: number;
+  /** Timeout in ms for the initial Copilot SDK `client.start()` call. Default 10_000. */
+  startTimeoutMs?: number;
   maxToolsPerRequest?: number;
   onToolCall?: (tool: string, args: unknown) => Promise<void>;
   onPermissionRequest?: PermissionRequestHandler;
@@ -681,7 +688,9 @@ export class CopilotWrapperService
   private authTimeoutMs: number;
   private started = false;
   private startFailed = false;
+  private lastStartError: string | null = null;
   private startPromise?: Promise<void>;
+  private startTimeoutMs: number;
   private pendingAuth?: Promise<AuthState>;
   private toolCallHandler?: (tool: string, args: unknown) => Promise<void>;
   private permissionHandler?: PermissionRequestHandler;
@@ -725,6 +734,7 @@ export class CopilotWrapperService
     clientId = process.env.GITHUB_CLIENT_ID ?? "",
     model = "gpt-4.1",
     authTimeoutMs = 5 * 60 * 1000,
+    startTimeoutMs = 10_000,
     maxToolsPerRequest = 30,
     sendAndWaitTimeoutMs = 15 * 60 * 1000, // 15 minutes — browser automation needs room
     onToolCall,
@@ -747,6 +757,7 @@ export class CopilotWrapperService
     this.clientId = clientId;
     this.model = model;
     this.authTimeoutMs = authTimeoutMs;
+    this.startTimeoutMs = startTimeoutMs;
     this.maxToolsPerRequest = maxToolsPerRequest;
     this.sendAndWaitTimeoutMs = sendAndWaitTimeoutMs;
     this.toolCallHandler = onToolCall;
@@ -902,9 +913,13 @@ export class CopilotWrapperService
     await this.ensureStarted();
 
     if (this.startFailed) {
+      const detail = this.lastStartError
+        ? `: ${this.lastStartError}`
+        : "";
       throw new Error(
-        "Copilot SDK is unavailable. The Copilot CLI may be outdated or missing. " +
-          "Please update your GitHub Copilot extension to get CLI version 0.0.394 or later.",
+        `Copilot SDK is unavailable${detail}. ` +
+          "See Copilot CLI troubleshooting in docs/USER_GUIDE.md, " +
+          "or POST /api/admin/copilot/restart after fixing the underlying issue.",
       );
     }
 
@@ -1102,7 +1117,11 @@ export class CopilotWrapperService
   async listModels(): Promise<CopilotModel[]> {
     await this.ensureStarted();
     if (this.startFailed) {
-      throw new Error("Copilot SDK failed to start — cannot list models");
+      const detail = this.lastStartError ? `: ${this.lastStartError}` : "";
+      throw new Error(
+        `Copilot SDK is unavailable${detail} — cannot list models. ` +
+          "See Copilot CLI troubleshooting in docs/USER_GUIDE.md.",
+      );
     }
     if (!this.client.listModels) {
       return [{ id: this.model }];
@@ -1132,6 +1151,7 @@ export class CopilotWrapperService
   private async doStart() {
     if (!this.client.start) {
       this.started = true;
+      this.lastStartError = null;
       return;
     }
     try {
@@ -1139,12 +1159,18 @@ export class CopilotWrapperService
         this.client.start(),
         new Promise<never>((_, reject) =>
           setTimeout(
-            () => reject(new Error("Copilot CLI start timed out after 10s")),
-            10_000,
+            () =>
+              reject(
+                new Error(
+                  `Copilot CLI start timed out after ${this.startTimeoutMs}ms`,
+                ),
+              ),
+            this.startTimeoutMs,
           ),
         ),
       ]);
       this.started = true;
+      this.lastStartError = null;
 
       // Subscribe to client-level lifecycle events (Phase 4)
       if (this.client.on) {
@@ -1165,9 +1191,63 @@ export class CopilotWrapperService
           },
         );
       }
-    } catch {
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      // Truncate to ~200 chars so the surfaced user message stays readable
+      // while still preserving enough signal for debugging.
+      const truncated =
+        detail.length > 200 ? `${detail.slice(0, 197)}...` : detail;
+      this.lastStartError = truncated;
       this.startFailed = true;
+      logger.error(
+        `Copilot SDK failed to start: ${truncated}`,
+        { category: "system", error: detail },
+      );
     }
+  }
+
+  /** Underlying detail of the most recent startup failure, or null. */
+  getLastStartError(): string | null {
+    return this.lastStartError;
+  }
+
+  /**
+   * Reset the start state and re-attempt SDK startup. Safe to call after
+   * a previous failure (e.g. after the user updated the Copilot CLI).
+   * Returns the outcome of the new attempt.
+   */
+  async restart(): Promise<{ ok: boolean; started: boolean; error?: string }> {
+    this.started = false;
+    this.startFailed = false;
+    this.lastStartError = null;
+    this.startPromise = undefined;
+    if (this.lifecycleUnsubscribe) {
+      try {
+        this.lifecycleUnsubscribe();
+      } catch {
+        // best-effort cleanup
+      }
+      this.lifecycleUnsubscribe = undefined;
+    }
+    try {
+      await this.ensureStarted();
+    } catch (err) {
+      // doStart() does not throw — it sets startFailed. But guard anyway
+      // in case a future change makes it throw.
+      const detail = err instanceof Error ? err.message : String(err);
+      if (!this.lastStartError) {
+        this.lastStartError = detail;
+        this.startFailed = true;
+      }
+    }
+    if (this.started) {
+      return { ok: true, started: true };
+    }
+    return {
+      ok: false,
+      started: false,
+      error: this.lastStartError ?? "Copilot SDK failed to start",
+    };
   }
 
   private async sendWithRetries(

--- a/src/server.ts
+++ b/src/server.ts
@@ -653,6 +653,7 @@ try {
 const copilot = new CopilotWrapperService({
   toolRegistry,
   maxToolsPerRequest: config.session?.maxToolsPerRequest ?? 30,
+  startTimeoutMs: config.copilot?.startTimeoutMs,
   infiniteSessions: config.session?.infiniteSessions,
   hooks: createHooksConfig({
     toolRegistry,

--- a/src/tasks/task-engine.ts
+++ b/src/tasks/task-engine.ts
@@ -91,6 +91,24 @@ export class TaskEngine extends EventEmitter {
     return task;
   }
 
+  /**
+   * Issue #945 — defer a task that hit a transient Copilot SDK outage.
+   * Resets the task to `queued` with an `awaiting_copilot_until` timestamp;
+   * the dequeue path will skip it until that time has passed. Never
+   * permanently fails the task on this error class. Emits `task:deferred`.
+   *
+   * @param taskId  Task to defer
+   * @param delayMs How long to hold the task before it can be re-dequeued
+   * @param error   Underlying error message to surface to operators
+   */
+  deferForCopilot(taskId: string, delayMs: number, error: string): AgentTask {
+    const until = new Date(Date.now() + Math.max(0, delayMs)).toISOString();
+    this.repository.deferForCopilot(taskId, until, error);
+    const task = this.repository.getById(taskId)!;
+    this.emit("task:deferred", task);
+    return task;
+  }
+
   /** Cancel a queued or running task. Emits `task:cancelled`. Returns the task or null. */
   cancel(taskId: string): AgentTask | null {
     const cancelled = this.repository.cancel(taskId);

--- a/src/tasks/task-repository.ts
+++ b/src/tasks/task-repository.ts
@@ -133,6 +133,12 @@ export class TaskRepository {
       this.db.exec("ALTER TABLE agent_tasks ADD COLUMN enable_in_session_subagents INTEGER NOT NULL DEFAULT 0");
     }
 
+    // Issue #945 — defer-until timestamp for tasks waiting on Copilot SDK restart.
+    // When set and in the future, dequeue() skips the row instead of failing it.
+    if (!columns.some((c) => c.name === "awaiting_copilot_until")) {
+      this.db.exec("ALTER TABLE agent_tasks ADD COLUMN awaiting_copilot_until TEXT DEFAULT NULL");
+    }
+
     // ── Backfill: link orphaned agent tasks to their parent ──
     // Before the parentTaskId propagation fix, spawn-agent/orchestrate-agents
     // never set parentTaskId. This backfill matches orphaned agent tasks to
@@ -265,18 +271,37 @@ export class TaskRepository {
     const row = this.db
       .prepare(
         `UPDATE agent_tasks
-         SET status = 'running', started_at = ?
+         SET status = 'running', started_at = ?, awaiting_copilot_until = NULL
          WHERE id = (
            SELECT id FROM agent_tasks
            WHERE status = 'queued'
+             AND (awaiting_copilot_until IS NULL OR awaiting_copilot_until <= ?)
            ORDER BY created_at ASC
            LIMIT 1
          )
          RETURNING *`
       )
-      .get(now) as StoredTask | undefined;
+      .get(now, now) as StoredTask | undefined;
 
     return row ? toTask(row) : null;
+  }
+
+  /**
+   * Issue #945 — defer a task that hit a transient Copilot SDK outage. Resets
+   * status to 'queued', stores the deferred-until timestamp, and writes the
+   * underlying error so operators can see why the task was held back.
+   */
+  deferForCopilot(id: string, untilISO: string, errorMsg: string): void {
+    this.db
+      .prepare(
+        `UPDATE agent_tasks
+         SET status = 'queued',
+             started_at = NULL,
+             error = ?,
+             awaiting_copilot_until = ?
+         WHERE id = ?`,
+      )
+      .run(errorMsg, untilISO, id);
   }
 
   /** Mark a task as running. */

--- a/src/tasks/task-worker.test.ts
+++ b/src/tasks/task-worker.test.ts
@@ -1397,4 +1397,74 @@ describe("TaskWorker", () => {
     const chatOptions = mockCopilot.chat.mock.calls[0][1] as { enableSubagents?: boolean };
     expect(chatOptions.enableSubagents).toBeUndefined();
   });
+
+  // ── Issue #945 — Copilot SDK unavailability handling ──
+  it("defers (rather than fails) tasks when chat throws 'Copilot SDK is unavailable'", async () => {
+    const mockCopilot = makeMockCopilot(async function* () {
+      yield "";
+      throw new Error(
+        "Copilot SDK is unavailable: Copilot CLI start timed out after 50ms",
+      );
+    });
+
+    worker = new TaskWorker({
+      engine,
+      copilot: mockCopilot,
+      maxConcurrent: 1,
+      pollIntervalMs: 25,
+      log: silentLog,
+    });
+
+    const task = engine.submit(
+      { trigger: "cron", goal: "Will hit unavailable SDK" },
+      { mode: "background" },
+    );
+
+    const deferredPromise = new Promise<void>((resolve) => {
+      worker.on("task:deferred", () => resolve());
+    });
+
+    worker.start();
+    await deferredPromise;
+
+    const stored = engine.getTask(task.id)!;
+    // Task is back to queued, never marked failed
+    expect(stored.status).toBe("queued");
+    expect(stored.error).toMatch(/Copilot SDK is unavailable/);
+    // Repository row carries the awaiting_copilot_until timestamp
+    const row = db
+      .prepare("SELECT awaiting_copilot_until FROM agent_tasks WHERE id = ?")
+      .get(task.id) as { awaiting_copilot_until: string | null };
+    expect(row.awaiting_copilot_until).not.toBeNull();
+    expect(new Date(row.awaiting_copilot_until!).getTime()).toBeGreaterThan(
+      Date.now() - 1_000,
+    );
+  });
+
+  it("dequeue() skips tasks whose awaiting_copilot_until is in the future", () => {
+    // Use the fixed-clock `now` (set in beforeEach) so the SQL comparison is deterministic.
+    const future = new Date(now.getTime() + 60_000).toISOString();
+    const past = new Date(now.getTime() - 1_000).toISOString();
+
+    const a = repo.insert({ trigger: "cron", goal: "deferred future" });
+    const b = repo.insert({ trigger: "cron", goal: "deferred past" });
+    const c = repo.insert({ trigger: "cron", goal: "ready" });
+
+    repo.deferForCopilot(a.id, future, "still down");
+    repo.deferForCopilot(b.id, past, "was down");
+
+    // Should claim 'b' first (created before c), then 'c', then nothing.
+    const first = repo.dequeue();
+    expect(first).not.toBeNull();
+    expect([b.id, c.id]).toContain(first!.id);
+    const second = repo.dequeue();
+    expect(second).not.toBeNull();
+    const third = repo.dequeue();
+    // 'a' is still deferred into the future, so it must NOT be claimed.
+    expect(third).toBeNull();
+    const claimed = [first!.id, second!.id];
+    expect(claimed).toContain(b.id);
+    expect(claimed).toContain(c.id);
+    expect(claimed).not.toContain(a.id);
+  });
 });

--- a/src/tasks/task-worker.ts
+++ b/src/tasks/task-worker.ts
@@ -11,6 +11,22 @@ import { normalizeLegacyStages } from "./pipeline-schema.js";
 import { waitForTask } from "./wait-for-task.js";
 import { logger } from "../logging/logger.js";
 
+/**
+ * Issue #945 — how long to hold a task off the queue after a Copilot SDK
+ * unavailability error. Operators have this window to call
+ * POST /api/admin/copilot/restart (or fix the underlying issue) before the
+ * task is re-attempted. Tasks remain queued indefinitely on repeat failures
+ * and are never permanently failed by this code path.
+ */
+const COPILOT_DEFER_DELAY_MS = 30_000;
+
+/**
+ * Marker substring thrown by CopilotWrapper when client.start() fails or
+ * times out. Kept as a literal contract so changes to the wrapper's wording
+ * are caught by the wrapper's own tests.
+ */
+const COPILOT_UNAVAILABLE_MARKER = "Copilot SDK is unavailable";
+
 export type TaskWorkerOptions = {
   engine: TaskEngine;
   copilot: CopilotWrapper;
@@ -258,6 +274,25 @@ export class TaskWorker extends EventEmitter {
       this.eventStreamer?.clearTask(task.id);
 
       const message = error instanceof Error ? error.message : String(error);
+
+      // Issue #945 — Copilot SDK transient outages are recoverable.
+      // Defer the task back onto the queue with an `awaiting_copilot_until`
+      // timestamp instead of permanently failing. Once the operator restarts
+      // the SDK (POST /api/admin/copilot/restart) the task will be picked up
+      // on the next dequeue tick after the delay window elapses.
+      if (this.isCopilotUnavailableError(message)) {
+        const deferred = this.engine.deferForCopilot(
+          task.id,
+          COPILOT_DEFER_DELAY_MS,
+          message,
+        );
+        this.log.warn(
+          `TaskWorker deferred task ${task.id} for ${COPILOT_DEFER_DELAY_MS}ms (Copilot SDK unavailable): ${message}`,
+        );
+        this.emit("task:deferred", deferred);
+        return;
+      }
+
       const failed = this.engine.fail(task.id, message);
       this.log.error(`TaskWorker failed task ${task.id}: ${message}`);
       this.emit("task:error", failed);
@@ -348,6 +383,15 @@ export class TaskWorker extends EventEmitter {
   }
 
   /**
+   * Issue #945 — returns true if the given error message originates from the
+   * CopilotWrapper signalling that the underlying Copilot CLI failed to start.
+   * Used to short-circuit permanent failure into a deferred re-queue.
+   */
+  private isCopilotUnavailableError(message: string): boolean {
+    return message.includes(COPILOT_UNAVAILABLE_MARKER);
+  }
+
+  /**
    * Execute a multi-stage pipeline. Supports both sequential prompt stages
    * and parallel groups (branches executed via Promise.all).
    *
@@ -381,7 +425,25 @@ export class TaskWorker extends EventEmitter {
         stageResults.push(...nodeResult.records);
 
         if (nodeResult.failed) {
-          const errorMsg = `Pipeline aborted at node "${node.name}": ${nodeResult.error ?? "unknown error"}`;
+          const nodeError = nodeResult.error ?? "unknown error";
+          // Issue #945 — even mid-pipeline, defer rather than fail when the
+          // SDK is unavailable. The pipeline will resume from this node when
+          // re-dequeued; partial state is not preserved (the whole task
+          // restarts), but the user retains the option to retry instead of
+          // losing the task entirely.
+          if (this.isCopilotUnavailableError(nodeError)) {
+            const deferred = this.engine.deferForCopilot(
+              task.id,
+              COPILOT_DEFER_DELAY_MS,
+              nodeError,
+            );
+            this.log.warn(
+              `TaskWorker pipeline deferred task ${task.id} at node "${node.name}" (Copilot SDK unavailable): ${nodeError}`,
+            );
+            this.emit("task:deferred", deferred);
+            return;
+          }
+          const errorMsg = `Pipeline aborted at node "${node.name}": ${nodeError}`;
           this.log.error(errorMsg);
           const failed = this.engine.fail(task.id, errorMsg);
           this.emit("task:error", failed);
@@ -400,6 +462,18 @@ export class TaskWorker extends EventEmitter {
       this.emit("task:done", completed);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      if (this.isCopilotUnavailableError(message)) {
+        const deferred = this.engine.deferForCopilot(
+          task.id,
+          COPILOT_DEFER_DELAY_MS,
+          message,
+        );
+        this.log.warn(
+          `TaskWorker pipeline deferred task ${task.id} for ${COPILOT_DEFER_DELAY_MS}ms (Copilot SDK unavailable): ${message}`,
+        );
+        this.emit("task:deferred", deferred);
+        return;
+      }
       const failed = this.engine.fail(task.id, `Pipeline error: ${message}`);
       this.log.error(`TaskWorker pipeline failed task ${task.id}: ${message}`);
       this.emit("task:error", failed);

--- a/ui/components/chat-view.tsx
+++ b/ui/components/chat-view.tsx
@@ -680,7 +680,7 @@ export const ChatView = () => {
       {/* Fallback warning */}
       {fallbackWarning && (
         <div className="border-b border-amber-600/30 bg-amber-500/10 px-5 py-2 text-center text-xs text-amber-700 dark:text-amber-400">
-          Copilot SDK unavailable — using fallback model list. Update your Copilot CLI to v0.0.394+ for full functionality.
+          Copilot SDK unavailable — using fallback model list. See Copilot CLI troubleshooting in <code className="font-mono">docs/USER_GUIDE.md</code>, then have an admin POST <code className="font-mono">/api/admin/copilot/restart</code> to recover.
         </div>
       )}
 


### PR DESCRIPTION
## Summary

Implements epic **#941** — _Harden Copilot SDK startup: surface real errors, allow recovery, prevent task cascade_ and all five sub-issues.

The previous `CopilotWrapperService.doStart()` swallowed the underlying `client.start()` error with a bare `catch {}` and returned a generic, hardcoded message instructing users to upgrade to a phantom CLI version (`0.0.394`). When the SDK was unhealthy at server boot, every background task in the queue marched to `failed` with the same opaque message, requiring a full server restart to recover. This PR makes the error path observable, recoverable, and non-cascading.

Closes #941
Closes #942
Closes #943
Closes #944
Closes #945
Closes #946

## What changed

### #943 — Reshape `doStart()` + `lastStartError` field
- `CopilotWrapperService` gains private `lastStartError: string | null` and exposes `getLastStartError()` on the `CopilotWrapper` interface.
- The `catch` in `doStart()` now logs the full error via Winston with `category: "system"`, stores a `~200 char` truncated copy on `lastStartError`, and surfaces it in every user-facing error message after the literal marker `Copilot SDK is unavailable: …`.
- `chat()` and `listModels()` error messages now include the underlying detail and a pointer to `docs/USER_GUIDE.md` + the new restart endpoint.
- The hardcoded `"0.0.394"` remediation string is **removed** — per [github/copilot-sdk#984](https://github.com/github/copilot-sdk/issues/984), the SDK bundles its own CLI and the version is not user-controllable.

### #942 — `copilot.startTimeoutMs` config knob
- New Zod-validated config key in `src/config/index.ts` (range `1000…120_000`, default `10_000`).
- Wired through `config/default.json` → `~/.openzigs/config.json` → env via the existing layered config in `src/server.ts`.
- `CopilotWrapperService` constructor accepts `startTimeoutMs?: number` and uses it in the `Promise.race` timeout for `client.start()`.

### #944 — `POST /api/admin/copilot/restart`
- New admin route in `src/api/admin.ts` (inside the existing `if (copilot)` block).
- Calls `copilot.restart()` which resets `started`, `startFailed`, `lastStartError`, and `startPromise`, unsubscribes the prior lifecycle listener, and re-invokes `ensureStarted()`.
- Returns `{ ok: true, started: true }` on success, `503 { ok: false, started: false, error }` on failed restart, `501` if the wrapper does not implement `restart`, `500` on thrown errors. All failures logged via Winston.

### #945 — TaskWorker no longer permanently fails on transient SDK outages
- New `awaiting_copilot_until TEXT` column on `agent_tasks`, added via the existing idempotent `ALTER TABLE` migration pattern (`pragma("table_info(agent_tasks)")` guard).
- `TaskRepository.dequeue()` now filters `WHERE status = 'queued' AND (awaiting_copilot_until IS NULL OR awaiting_copilot_until <= ?)` so deferred rows are skipped until their timestamp passes.
- New `TaskRepository.deferForCopilot(id, untilISO, errorMsg)` and `TaskEngine.deferForCopilot(taskId, delayMs, error)` reset the row to `status='queued'`, store the deferred-until timestamp, and emit `task:deferred`.
- `TaskWorker` checks for the `Copilot SDK is unavailable` marker in three failure paths (single-task, pipeline outer catch, pipeline node-failure) and routes to `engine.deferForCopilot(task.id, 30_000, message)` instead of `engine.fail(...)`. Tasks resume automatically on the next poll cycle once the timestamp passes.

### #946 — `docs/USER_GUIDE.md` Copilot CLI Troubleshooting subsection
- New subsection covering: (a) what the `Copilot SDK is unavailable` marker means and common causes, (b) how `@github/copilot-sdk` bundles its CLI per the upstream issue, (c) the new restart endpoint with example response bodies, (d) the configurable `startTimeoutMs` knob with bounds and tuning guidance.

## Design decisions

- **Why `awaiting_copilot_until` (timestamp column) instead of a new `awaiting_copilot` status?** The `agent_tasks` table has a `CHECK (status IN ('queued','running','completed','failed','cancelled'))` constraint. Adding a new status value would have required a full table-recreate migration. A nullable timestamp column on top of `status='queued'` is additive, idempotent, and keeps the existing dequeue ordering invariant.
- **Why defer-30s-and-retry-indefinitely instead of retry-once-then-fail?** Sub-issue #945 explicitly asks: _“Never permanently fail the task on this error class on first encounter.”_ Operators are expected to call `POST /api/admin/copilot/restart` after fixing the underlying problem; deferred tasks then resume automatically at the next poll. If the operator does nothing, the task simply keeps re-deferring at 30s intervals — no work is lost.
- **Why log the error inside `doStart()` rather than at the call sites?** The catch is the single point where every code path (chat, listModels, restart) converges. Logging there guarantees one structured log entry per failure regardless of how many downstream call sites later throw.

## Quality gate

```
pnpm typecheck   ✓ (clean)
pnpm lint        ✓ (clean)
pnpm test --run  ✓ (346 files, 6525 tests, all passing)
ui: npx next build  ✓ (clean)
```

Notable test additions:
- `src/copilot/copilot-wrapper.test.ts` — 4 new tests: error message contract, no hardcoded CLI version, custom `startTimeoutMs`, `restart()` happy + failure paths.
- `src/tasks/task-worker.test.ts` — 2 new tests: defer-instead-of-fail on the unavailability marker, dequeue skips future-dated `awaiting_copilot_until`.

## Versioning

CHANGELOG `## [Unreleased]` updated with `### Added (Epic #941)` and `### Fixed (Epic #941)` entries. **`package.json` version intentionally not bumped** per workflow conventions (epic-level work, not a release).
