### PR TITLE
fix(pitch): walkthrough bug batch — generate UX, exports wiring, regenerate, notes editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed (Epic #951 — Studio → Pitch Walkthrough Bug Batch)
+
+- Pitch deck draft no longer aborts before LLM completes (timeout raised to 240s, progress UI added).
+- Pitch export menu wired up (PDF, PPTX, Markdown, Speaker Notes, ZIP).
+- Pitch slide regenerate-text action exposed in slide menu.
+- Per-slide speaker notes now editable in properties panel.
+- Pitch generator now respects slide-count target with explicit retry.
+- Regenerate-image dialog uses field's current prompt value.
+
+### Added (Epic #951 — Studio → Pitch Walkthrough Bug Batch)
+
+- Structured 503 response when Decktape/Chromium unavailable.
+- `aria-describedby` on pitch dialogs for screen readers.
+
 ### Security (Epic #951 — Studio → Pitch Phase 7)
 
 - **Per-route rate limiting (#977):** Every Pitch route now wears an `express-rate-limit` instance built by an in-router `buildLimiter(max, label)` factory (1-hour window, standard `RateLimit-*` + `Retry-After` headers, `429 { error: { code: "rate_limited" } }` on overflow). Limits: draft 10/hr, regenerate 60/hr, enhance 60/hr, image enqueue 30/hr, PDF 20/hr, PPTX 30/hr, ZIP 30/hr, MD 60/hr, HTML 60/hr, speaker-notes PDF 20/hr, CRUD 600/hr.

--- a/src/api/pitch.test.ts
+++ b/src/api/pitch.test.ts
@@ -1575,5 +1575,40 @@ describe("Pitch REST router", () => {
         expect(res.body.error.message, `ext=${ext}`).not.toMatch(/decktape|pptxgen|archiver/);
       }
     });
+
+    it("returns 503 pdf_export_unavailable when decktape spawn fails (ENOENT)", async () => {
+      const deckId = await setupDeck();
+      // Mimic what `child_process.spawn` rejects with when the binary is
+      // missing — message includes 'spawn decktape ENOENT' AND `code` is
+      // set to 'ENOENT'. Either signal alone is sufficient for the
+      // detection helper; we set both to prove the contract.
+      const enoentErr = Object.assign(new Error("spawn decktape ENOENT"), {
+        code: "ENOENT",
+      });
+      const exporters = {
+        pdf: vi.fn().mockRejectedValue(enoentErr),
+        pptx: vi.fn(),
+        zip: vi.fn(),
+        md: vi.fn(),
+        notes: vi.fn().mockRejectedValue(enoentErr),
+      };
+      const newDeps: PitchRouterDeps = { ...harness.deps, exporters };
+      const app = express();
+      app.use(express.json());
+      app.use("/api/admin/pitch", createPitchRouter(newDeps));
+
+      const pdfRes = await request(app).get(
+        `/api/admin/pitch/decks/${deckId}/export.pdf`,
+      );
+      expect(pdfRes.status).toBe(503);
+      expect(pdfRes.body.error.code).toBe("pdf_export_unavailable");
+      expect(pdfRes.body.error.message).toMatch(/decktape/i);
+
+      const notesRes = await request(app).get(
+        `/api/admin/pitch/decks/${deckId}/export.notes.pdf`,
+      );
+      expect(notesRes.status).toBe(503);
+      expect(notesRes.body.error.code).toBe("pdf_export_unavailable");
+    });
   });
 });

--- a/src/api/pitch.ts
+++ b/src/api/pitch.ts
@@ -142,7 +142,8 @@ type ErrorCode =
   | "forbidden"
   | "conflict"
   | "bad_request"
-  | "internal_error";
+  | "internal_error"
+  | "pdf_export_unavailable";
 
 function sendError(
   res: Response,
@@ -599,6 +600,26 @@ export function createPitchRouter(deps: PitchRouterDeps): Router {
   const mdExporter = deps.exporters?.md ?? exportDeckToMarkdown;
   const notesExporter = deps.exporters?.notes ?? exportNotesToPdf;
 
+  /**
+   * True if the error looks like a Decktape/Chromium spawn failure
+   * (binary missing, not executable, headless launch crashed). We surface
+   * these as 503 with a structured body so the UI can prompt the user to
+   * warm the cache instead of showing a generic "PDF export failed" toast.
+   */
+  const isPdfToolUnavailable = (err: unknown): boolean => {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "ENOENT" || code === "EACCES" || code === "ENOTDIR") return true;
+    const msg = errMessage(err).toLowerCase();
+    return (
+      msg.includes("enoent") ||
+      msg.includes("spawn decktape") ||
+      msg.includes("decktape: not found") ||
+      msg.includes("chromium") && msg.includes("failed")
+    );
+  };
+  const PDF_UNAVAILABLE_DETAIL =
+    "Decktape/Chromium failed to start. Run `npx decktape --version` to warm the cache.";
+
   type DeckCtx = {
     deck: ReturnType<PitchRepository["getDeck"]>;
     brandKit: PitchBrandKit;
@@ -762,6 +783,10 @@ export function createPitchRouter(deps: PitchRouterDeps): Router {
       logger.error(
         `[Pitch API] GET /decks/${req.params.deckId}/export.pdf failed: ${errMessage(err)}`,
       );
+      if (isPdfToolUnavailable(err)) {
+        sendError(res, 503, "pdf_export_unavailable", PDF_UNAVAILABLE_DETAIL);
+        return;
+      }
       // Generic message — never leak subprocess stderr to clients.
       sendError(res, 500, "internal_error", "pdf export failed");
     }
@@ -797,6 +822,10 @@ export function createPitchRouter(deps: PitchRouterDeps): Router {
       logger.error(
         `[Pitch API] GET /decks/${req.params.deckId}/export.notes.pdf failed: ${errMessage(err)}`,
       );
+      if (isPdfToolUnavailable(err)) {
+        sendError(res, 503, "pdf_export_unavailable", PDF_UNAVAILABLE_DETAIL);
+        return;
+      }
       sendError(res, 500, "internal_error", "notes pdf export failed");
     }
   });

--- a/src/pitch/pitch-generator.test.ts
+++ b/src/pitch/pitch-generator.test.ts
@@ -269,6 +269,52 @@ describe("generateDeck", () => {
     // Truncated from the FRONT — slide 0 should still be the first one.
     expect(deck.slides[0].template).toBe("bullet_list");
   });
+
+  it("retries with an explicit count instruction when the model returns the wrong slide count", async () => {
+    // First payload: valid schema but only 2 slides when 5 were asked for.
+    // Retry payload: 5 slides matching the target.
+    const fiveSlides = [
+      VALID_SLIDES[0],
+      VALID_SLIDES[0],
+      VALID_SLIDES[0],
+      VALID_SLIDES[0],
+      VALID_SLIDES[1],
+    ];
+    const retryPayload = JSON.stringify({
+      title: "Retry Deck",
+      aspect_ratio: "16:9",
+      slides: fiveSlides,
+      metadata: { source_script: "x", tone: "formal" },
+    });
+    const { copilot, chat } = mockCopilot([VALID_DECK_PAYLOAD, retryPayload]);
+    const deck = await generateDeck({
+      script: "x",
+      brandKit: KIT,
+      options: { targetSlideCount: 5 },
+      copilot,
+      clock: FROZEN_CLOCK,
+    });
+    expect(chat).toHaveBeenCalledTimes(2);
+    expect(deck.slides).toHaveLength(5);
+    const retryMsg = chat.mock.calls[1][0] as string;
+    expect(retryMsg).toContain("You returned 2 slides");
+    expect(retryMsg).toContain("exactly 5");
+  });
+
+  it("returns the first-pass deck when the retry also misses the slide count target", async () => {
+    // Both passes return 2 slides instead of the requested 5. We accept the
+    // first pass rather than 500ing the user.
+    const { copilot, chat } = mockCopilot([VALID_DECK_PAYLOAD, VALID_DECK_PAYLOAD]);
+    const deck = await generateDeck({
+      script: "x",
+      brandKit: KIT,
+      options: { targetSlideCount: 5 },
+      copilot,
+      clock: FROZEN_CLOCK,
+    });
+    expect(chat).toHaveBeenCalledTimes(2);
+    expect(deck.slides).toHaveLength(2);
+  });
 });
 
 describe("regenerateSlide", () => {

--- a/src/pitch/pitch-generator.ts
+++ b/src/pitch/pitch-generator.ts
@@ -18,6 +18,7 @@
 import { nanoid } from "nanoid";
 import { z } from "zod";
 import type { CopilotWrapper } from "../copilot/copilot-wrapper.js";
+import { logger } from "../logging/logger.js";
 import {
   DeckSchema,
   SlideSchema,
@@ -117,19 +118,59 @@ export async function generateDeck(opts: GenerateDeckOpts): Promise<Deck> {
     wrapUserScript(opts.script ?? ""),
   ].join("\n");
 
-  // Initial call — parse + validate; on failure, retry ONCE with the error.
+  // Initial call \u2014 parse + validate; on failure OR slide-count mismatch
+  // (when the caller asked for a specific count), retry ONCE with a
+  // targeted hint. The retry budget is shared across both failure modes.
   let lastError: unknown = null;
+  let lastDeck: Deck | null = null;
   let raw = await callOnce(opts, userPrompt, systemPrompt);
   try {
-    return assembleDeck(raw, opts);
+    const deck = assembleDeck(raw, opts);
+    if (
+      opts.options?.targetSlideCount === undefined ||
+      deck.slides.length === targetSlideCount
+    ) {
+      return deck;
+    }
+    // Wrong slide count \u2014 fall through to retry with explicit count
+    // instruction. Preserve the partial deck so a second failure can
+    // still hand back something usable instead of throwing.
+    lastDeck = deck;
   } catch (err) {
     lastError = err;
   }
 
-  // Retry pass — embed the validation error so the model can self-correct.
-  const retryPrompt = [userPrompt, "", buildRetryHint(lastError)].join("\n");
+  // Retry pass \u2014 either embed the validation error so the model can
+  // self-correct, OR explicitly call out the slide-count miss.
+  const retryReason =
+    lastError !== null
+      ? buildRetryHint(lastError)
+      : `You returned ${lastDeck?.slides.length ?? "?"} slides, but I asked for exactly ${targetSlideCount}. Return EXACTLY ${targetSlideCount} slides \u2014 no more, no fewer.`;
+  const retryPrompt = [userPrompt, "", retryReason].join("\n");
   raw = await callOnce(opts, retryPrompt, systemPrompt);
-  return assembleDeck(raw, opts);
+  try {
+    const deck = assembleDeck(raw, opts);
+    if (
+      opts.options?.targetSlideCount !== undefined &&
+      deck.slides.length !== targetSlideCount
+    ) {
+      logger.warn(
+        `[pitch-generator] retry produced ${deck.slides.length} slides, target was ${targetSlideCount}; returning anyway`,
+      );
+    }
+    return deck;
+  } catch (err) {
+    // Second attempt failed validation. If the FIRST attempt produced a
+    // valid (but wrong-count) deck, hand that back rather than 500ing the
+    // user \u2014 a deck with the wrong slide count is still usable.
+    if (lastDeck) {
+      logger.warn(
+        `[pitch-generator] retry failed (${err instanceof Error ? err.message : String(err)}); returning first-pass deck with ${lastDeck.slides.length}/${targetSlideCount} slides`,
+      );
+      return lastDeck;
+    }
+    throw err;
+  }
 }
 
 /**

--- a/ui/app/pitch/[deckId]/page.test.tsx
+++ b/ui/app/pitch/[deckId]/page.test.tsx
@@ -139,6 +139,35 @@ vi.mock("@/components/pitch/brand-kit-editor", () => ({
   ),
 }));
 
+// Replace the Radix DropdownMenu with a transparent passthrough so menu
+// items render unconditionally — Radix's portal-based rendering does not
+// behave reliably in jsdom (no pointer events) and we only care about the
+// shell wiring here.
+vi.mock("@/components/ui/dropdown-menu", () => {
+  const Pass = ({ children }: { children: ReactNode }) => <>{children}</>;
+  return {
+    DropdownMenu: Pass,
+    DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
+      <>{children}</>
+    ),
+    DropdownMenuContent: Pass,
+    DropdownMenuItem: ({
+      children,
+      onSelect,
+      ...rest
+    }: {
+      children: ReactNode;
+      onSelect?: () => void;
+    } & Record<string, unknown>) => (
+      <button onClick={() => onSelect?.()} {...rest}>
+        {children}
+      </button>
+    ),
+    DropdownMenuLabel: Pass,
+    DropdownMenuSeparator: () => null,
+  };
+});
+
 import { fetchJson } from "@/lib/api";
 import PitchDeckEditorPage from "./page";
 
@@ -192,6 +221,17 @@ describe("PitchDeckEditorPage", () => {
       status: 200,
       text: async () => sampleHtml,
     }) as unknown as typeof fetch;
+    // jsdom does not implement URL.createObjectURL/revokeObjectURL.
+    // The export-download helper schedules a `revokeObjectURL` via
+    // `setTimeout(..., 1000)` that fires AFTER the test has resolved, so
+    // the stubs must remain installed for the duration of the suite —
+    // never restore them.
+    type UrlWithBlob = typeof URL & {
+      createObjectURL: (blob: Blob) => string;
+      revokeObjectURL: (url: string) => void;
+    };
+    (URL as UrlWithBlob).createObjectURL = vi.fn(() => "blob:mock");
+    (URL as UrlWithBlob).revokeObjectURL = vi.fn();
   });
 
   it("renders all four editor zones once data loads", async () => {
@@ -213,7 +253,61 @@ describe("PitchDeckEditorPage", () => {
     await waitFor(() =>
       expect(screen.getByTestId("pitch-editor-shell")).toBeInTheDocument(),
     );
-    expect(screen.getByTestId("pitch-editor-export")).toBeDisabled();
+    // Phase 6 shipped — the export trigger is now an enabled dropdown.
+    const trigger = screen.getByTestId("pitch-editor-export");
+    expect(trigger).not.toBeDisabled();
+  });
+
+  it("opens the export menu and lists every export format", async () => {
+    render(<PitchDeckEditorPage />, { wrapper });
+    await waitFor(() =>
+      expect(screen.getByTestId("pitch-editor-shell")).toBeInTheDocument(),
+    );
+    // With the dropdown mocked to pass-through, every menu item renders
+    // unconditionally — verify each format is present.
+    for (const fmt of ["pdf", "pptx", "md", "notes", "zip"]) {
+      expect(
+        screen.getByTestId(`pitch-editor-export-${fmt}`),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("downloads the requested format when an export menu item is selected", async () => {
+    const exportBlob = new Blob(["%PDF-1.4 stub"], { type: "application/pdf" });
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("/render")) {
+        return {
+          ok: true,
+          status: 200,
+          text: async () => sampleHtml,
+        } as unknown as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        headers: {
+          get: (k: string) =>
+            k.toLowerCase() === "content-disposition"
+              ? 'attachment; filename="my-deck.pdf"'
+              : null,
+        },
+        blob: async () => exportBlob,
+      } as unknown as Response;
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<PitchDeckEditorPage />, { wrapper });
+    await waitFor(() =>
+      expect(screen.getByTestId("pitch-editor-shell")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("pitch-editor-export-pdf"));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("/api/admin/pitch/decks/deck-1/export.pdf"),
+        expect.any(Object),
+      ),
+    );
   });
 
   it("forwards canvas data-pitch-field clicks (selectedField is consumed by the properties panel)", async () => {

--- a/ui/app/pitch/[deckId]/page.tsx
+++ b/ui/app/pitch/[deckId]/page.tsx
@@ -19,6 +19,12 @@ import {
   type BrandKitListEntry,
 } from "@/components/pitch/brand-kit-picker";
 import { BrandKitEditor } from "@/components/pitch/brand-kit-editor";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 interface DeckSlideRow {
   id: string;
@@ -79,6 +85,62 @@ async function fetchRenderHtml(deckId: string): Promise<string> {
     throw new Error(`render failed: ${res.status}`);
   }
   return res.text();
+}
+
+interface ExportFormat {
+  id: "pdf" | "pptx" | "md" | "notes" | "zip";
+  label: string;
+  /** Path appended to `/api/admin/pitch/decks/:deckId`. */
+  suffix: string;
+}
+
+const EXPORT_FORMATS: ReadonlyArray<ExportFormat> = [
+  { id: "pdf", label: "PDF", suffix: "/export.pdf" },
+  { id: "pptx", label: "PowerPoint (.pptx)", suffix: "/export.pptx" },
+  { id: "md", label: "Markdown", suffix: "/export.md" },
+  { id: "notes", label: "Speaker Notes (PDF)", suffix: "/export.notes.pdf" },
+  { id: "zip", label: "ZIP Bundle", suffix: "/export.zip" },
+];
+
+/**
+ * Trigger an authenticated download via fetch \u2192 blob \u2192 anchor click.
+ * We can't just `window.open` the URL because the API requires the bearer
+ * token in the `Authorization` header, not a query string. On non-2xx the
+ * backend's structured `{ error: { message } }` envelope is surfaced.
+ */
+async function downloadExport(
+  deckId: string,
+  format: ExportFormat,
+): Promise<void> {
+  const url = buildUrl(`/api/admin/pitch/decks/${deckId}${format.suffix}`);
+  const headers: HeadersInit = AUTH_TOKEN
+    ? { Authorization: `Bearer ${AUTH_TOKEN}` }
+    : {};
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    let detail = `HTTP ${res.status}`;
+    try {
+      const body = (await res.json()) as { error?: { message?: string } };
+      if (body?.error?.message) detail = body.error.message;
+    } catch {
+      // not JSON \u2014 fall back to status text
+      if (res.statusText) detail = res.statusText;
+    }
+    throw new Error(detail);
+  }
+  const blob = await res.blob();
+  const objectUrl = URL.createObjectURL(blob);
+  const cd = res.headers.get("Content-Disposition") ?? "";
+  const match = /filename="?([^";]+)"?/i.exec(cd);
+  const filename = match?.[1] ?? `deck-${deckId}${format.suffix.replace("/export", "")}`;
+  const a = document.createElement("a");
+  a.href = objectUrl;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  // Revoke async so the browser has time to start the download.
+  setTimeout(() => URL.revokeObjectURL(objectUrl), 1_000);
 }
 
 export default function PitchDeckEditorPage() {
@@ -215,6 +277,20 @@ export default function PitchDeckEditorPage() {
       queryClient.invalidateQueries({ queryKey: ["pitch", "render", deckId] });
     },
     onError: () => showToast("Duplicate slide failed.", "error"),
+  });
+
+  const regenerateSlideMutation = useMutation({
+    mutationFn: async (slideId: string) =>
+      fetchJson<{ taskId: string }>(
+        `/api/admin/pitch/decks/${deckId}/slides/${slideId}/regenerate`,
+        { method: "POST", body: JSON.stringify({}) },
+      ),
+    onSuccess: () => showToast("Regenerating slide text\u2026", "success"),
+    onError: (err) =>
+      showToast(
+        `Regenerate failed: ${err instanceof Error ? err.message : String(err)}`,
+        "error",
+      ),
   });
 
   // ── Socket subscriptions ─────────────────────────────────────────────
@@ -365,14 +441,37 @@ export default function PitchDeckEditorPage() {
               setBrandKitDialogOpen(true);
             }}
           />
-          <button
-            disabled
-            data-testid="pitch-editor-export"
-            title="Coming in Phase 6"
-            className="rounded border border-border px-2 py-1 text-xs opacity-50"
-          >
-            Export
-          </button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                data-testid="pitch-editor-export"
+                className="rounded border border-border px-2 py-1 text-xs hover:bg-muted/40"
+              >
+                Export
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {EXPORT_FORMATS.map((fmt) => (
+                <DropdownMenuItem
+                  key={fmt.id}
+                  data-testid={`pitch-editor-export-${fmt.id}`}
+                  onSelect={async () => {
+                    try {
+                      await downloadExport(deckId, fmt);
+                    } catch (err) {
+                      showToast(
+                        `Export failed: ${err instanceof Error ? err.message : String(err)}`,
+                        "error",
+                      );
+                    }
+                  }}
+                >
+                  {fmt.label}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
           <span
             data-testid="pitch-editor-save-state"
             data-state={saveState}
@@ -408,6 +507,7 @@ export default function PitchDeckEditorPage() {
         }}
         onDuplicate={(slideId) => duplicateSlideMutation.mutate(slideId)}
         onDelete={(slideId) => deleteSlideMutation.mutate(slideId)}
+        onRegenerate={(slideId) => regenerateSlideMutation.mutate(slideId)}
       />
 
       {/* Canvas */}

--- a/ui/app/pitch/new/page.tsx
+++ b/ui/app/pitch/new/page.tsx
@@ -17,7 +17,7 @@ interface BrandKitsResponse {
 }
 
 const SCRIPT_BYTE_CAP = 50_000;
-const DRAFT_TIMEOUT_MS = 90_000;
+const DRAFT_TIMEOUT_MS = 240_000;
 
 const AUTH_TOKEN =
   typeof process !== "undefined"
@@ -121,14 +121,32 @@ export default function NewPitchDeckPage() {
         }),
       });
       if (!res.ok) {
-        const text = await res.text();
-        throw new Error(text || `HTTP ${res.status}`);
+        // Try to surface the backend's structured `{ error: { message } }`
+        // envelope; fall back to plain text so we never throw "undefined".
+        let detail = `HTTP ${res.status}`;
+        try {
+          const body = (await res.json()) as {
+            error?: { message?: string };
+          };
+          if (body?.error?.message) detail = body.error.message;
+        } catch {
+          const text = await res.text().catch(() => "");
+          if (text) detail = text;
+        }
+        throw new Error(detail);
       }
       const data = (await res.json()) as { deck: { id: string } };
       router.push(`/pitch/${data.deck.id}`);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      showToast(`Could not draft deck: ${msg}`, "error");
+      if (err instanceof DOMException && err.name === "AbortError") {
+        showToast(
+          `Generation timed out after ${Math.round(DRAFT_TIMEOUT_MS / 1000)}s. The model may be cold-starting — please try again.`,
+          "error",
+        );
+      } else {
+        const msg = err instanceof Error ? err.message : String(err);
+        showToast(`Could not draft deck: ${msg}`, "error");
+      }
     } finally {
       clearTimeout(timer);
       setSubmitting(false);
@@ -254,7 +272,7 @@ export default function NewPitchDeckPage() {
             <div className="mt-3">
               <label className="text-xs font-semibold">Slide count target</label>
               <div className="mt-1 flex gap-2" data-testid="wizard-slide-count">
-                {[5, 10, 15, 20].map((n) => (
+                {[5, 8, 10, 15, 20].map((n) => (
                   <button
                     key={n}
                     type="button"
@@ -352,6 +370,23 @@ export default function NewPitchDeckPage() {
             </button>
           )}
         </div>
+        {submitting && step === "options" && (
+          <div
+            data-testid="wizard-progress"
+            role="status"
+            aria-live="polite"
+            className="mt-4 flex items-start gap-2 rounded border border-primary/30 bg-primary/5 p-3 text-xs text-foreground"
+          >
+            <span
+              className="mt-0.5 inline-block h-3 w-3 shrink-0 animate-spin rounded-full border-2 border-primary border-t-transparent"
+              aria-hidden="true"
+            />
+            <span>
+              Generating ~{slideCount} slides &mdash; this can take up to 3 minutes
+              while the model warms up. Please don&apos;t close this tab.
+            </span>
+          </div>
+        )}
       </div>
       <BrandKitEditor
         open={createKitOpen}

--- a/ui/components/pitch/brand-kit-editor.test.tsx
+++ b/ui/components/pitch/brand-kit-editor.test.tsx
@@ -26,6 +26,7 @@ vi.mock("@/components/ui/dialog", () => ({
   DialogHeader: ({ children }: { children: ReactNode }) => <>{children}</>,
   DialogFooter: ({ children }: { children: ReactNode }) => <>{children}</>,
   DialogTitle: ({ children }: { children: ReactNode }) => <h3>{children}</h3>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
 }));
 
 import { fetchJson } from "@/lib/api";

--- a/ui/components/pitch/brand-kit-editor.tsx
+++ b/ui/components/pitch/brand-kit-editor.tsx
@@ -21,6 +21,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -241,6 +242,11 @@ export const BrandKitEditor = ({
           <DialogTitle>
             {isCreate ? "New brand kit" : isStarter ? "Starter brand kit" : "Edit brand kit"}
           </DialogTitle>
+          <DialogDescription>
+            Define brand colors, fonts, and footer text. New decks pick
+            up these defaults; existing decks are unaffected until you
+            switch their brand kit.
+          </DialogDescription>
         </DialogHeader>
 
         {isStarter && (

--- a/ui/components/pitch/properties-panel.test.tsx
+++ b/ui/components/pitch/properties-panel.test.tsx
@@ -171,4 +171,44 @@ describe("PropertiesPanel", () => {
       screen.getByTestId("pitch-properties-unknown-template"),
     ).toBeInTheDocument();
   });
+
+  it("renders the speaker-notes textarea and PATCHes when edited", async () => {
+    vi.mocked(fetchJson).mockResolvedValue({});
+    render(
+      <PropertiesPanel
+        deckId="d"
+        selectedSlide={{
+          id: "s1",
+          slide: {
+            template: "title",
+            content: { title: "Hi" },
+            speaker_notes: "initial",
+          },
+        }}
+      />,
+      { wrapper },
+    );
+    const ta = (await screen.findByTestId(
+      "pitch-properties-speaker-notes",
+    )) as HTMLTextAreaElement;
+    expect(ta.value).toBe("initial");
+
+    fireEvent.change(ta, { target: { value: "new notes" } });
+    expect((screen.getByTestId(
+      "pitch-properties-speaker-notes",
+    ) as HTMLTextAreaElement).value).toBe("new notes");
+
+    await act(async () => {
+      vi.advanceTimersByTime(401);
+    });
+    await waitFor(() =>
+      expect(vi.mocked(fetchJson)).toHaveBeenCalledWith(
+        "/api/admin/pitch/decks/d/slides/s1",
+        expect.objectContaining({
+          method: "PATCH",
+          body: expect.stringContaining("\"speaker_notes\":\"new notes\""),
+        }),
+      ),
+    );
+  });
 });

--- a/ui/components/pitch/properties-panel.tsx
+++ b/ui/components/pitch/properties-panel.tsx
@@ -193,6 +193,29 @@ export const PropertiesPanel = ({
             deckId={deckId}
             brandKit={brandKit ?? null}
           />
+          <div className="mt-4 border-t border-border pt-3">
+            <label
+              htmlFor="pitch-properties-speaker-notes"
+              className="mb-1 block text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+            >
+              Speaker notes
+            </label>
+            <textarea
+              id="pitch-properties-speaker-notes"
+              data-testid="pitch-properties-speaker-notes"
+              value={draft.speaker_notes ?? ""}
+              onChange={(e) =>
+                handleEditorChange({
+                  ...draft,
+                  speaker_notes: e.target.value,
+                } as PitchSlideShape)
+              }
+              rows={4}
+              maxLength={2000}
+              placeholder="Notes shown only to the presenter\u2026"
+              className="w-full resize-y rounded border border-border bg-background px-2 py-1 text-xs"
+            />
+          </div>
         </>
       ) : (
         <div

--- a/ui/components/pitch/property-editors/title.tsx
+++ b/ui/components/pitch/property-editors/title.tsx
@@ -82,7 +82,10 @@ const TitleEditor = ({ slide, onChange, deckId }: PropertyEditorProps<TitleSlide
         onOpenChange={setOpen}
         deckId={deckId}
         slideId={(slide as TitleSlide & { id?: string }).id ?? ""}
-        initialPrompt={slide.background_image_prompt ?? c.title ?? ""}
+        // Bug #6 \u2014 prefill with the textarea's current value, not the
+        // slide title. Falling back to title made an edit to the bg-prompt
+        // appear to be ignored.
+        initialPrompt={slide.background_image_prompt ?? ""}
         mode="background"
       />
     </div>

--- a/ui/components/pitch/regenerate-image-dialog.test.tsx
+++ b/ui/components/pitch/regenerate-image-dialog.test.tsx
@@ -24,6 +24,7 @@ vi.mock("@/components/ui/dialog", () => ({
   DialogHeader: ({ children }: { children: ReactNode }) => <>{children}</>,
   DialogFooter: ({ children }: { children: ReactNode }) => <>{children}</>,
   DialogTitle: ({ children }: { children: ReactNode }) => <h3>{children}</h3>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
 }));
 
 import { fetchJson } from "@/lib/api";

--- a/ui/components/pitch/regenerate-image-dialog.tsx
+++ b/ui/components/pitch/regenerate-image-dialog.tsx
@@ -12,11 +12,12 @@
  * doesn't pay for the dropdown when the user never opens the dialog.
  */
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -60,6 +61,18 @@ export const RegenerateImageDialog = ({
   const [loraId, setLoraId] = useState<string>("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Bug #6 — the dialog stays mounted while `open=false`, so `useState`'s
+  // lazy initializer only runs once and the prompt would be stuck at the
+  // value held when the editor first rendered. Re-sync from `initialPrompt`
+  // every time the dialog re-opens so the user's most recent textarea edit
+  // is what actually gets prefilled.
+  useEffect(() => {
+    if (open) {
+      setPrompt(initialPrompt);
+      setError(null);
+    }
+  }, [open, initialPrompt]);
 
   const charactersQuery = useQuery({
     queryKey: ["pitch", "characters"],
@@ -109,6 +122,10 @@ export const RegenerateImageDialog = ({
       >
         <DialogHeader>
           <DialogTitle>Regenerate image</DialogTitle>
+          <DialogDescription>
+            Provide a new prompt to regenerate this image. The current
+            asset stays in place until the new render finishes.
+          </DialogDescription>
         </DialogHeader>
         <div className="space-y-3 text-xs">
           <label className="block">

--- a/ui/components/pitch/slide-rail.tsx
+++ b/ui/components/pitch/slide-rail.tsx
@@ -42,6 +42,13 @@ export interface SlideRailProps {
   onAddBelow: (slideId: string) => void;
   onDuplicate: (slideId: string) => void;
   onDelete: (slideId: string) => void;
+  /**
+   * Optional — when present, surfaces a "Regenerate text" menu item that
+   * fires the per-slide LLM regenerate task. Wired in the editor shell
+   * (`ui/app/pitch/[deckId]/page.tsx`) to POST
+   * `/decks/:deckId/slides/:slideId/regenerate`.
+   */
+  onRegenerate?: (slideId: string) => void;
 }
 
 export const SlideRail = ({
@@ -53,6 +60,7 @@ export const SlideRail = ({
   onAddBelow,
   onDuplicate,
   onDelete,
+  onRegenerate,
 }: SlideRailProps) => {
   const [pendingDelete, setPendingDelete] = useState<string | null>(null);
   // Local copy so we can do optimistic reorder + rollback on failure.
@@ -123,6 +131,7 @@ export const SlideRail = ({
                   onAddAbove={onAddAbove}
                   onAddBelow={onAddBelow}
                   onDuplicate={onDuplicate}
+                  onRegenerate={onRegenerate}
                   onRequestDelete={(id) => setPendingDelete(id)}
                 />
               ))}
@@ -152,6 +161,7 @@ interface RowProps {
   onAddAbove: (id: string) => void;
   onAddBelow: (id: string) => void;
   onDuplicate: (id: string) => void;
+  onRegenerate?: (id: string) => void;
   onRequestDelete: (id: string) => void;
 }
 
@@ -163,6 +173,7 @@ const SlideRailRow = ({
   onAddAbove,
   onAddBelow,
   onDuplicate,
+  onRegenerate,
   onRequestDelete,
 }: RowProps) => {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
@@ -220,6 +231,14 @@ const SlideRailRow = ({
             <DropdownMenuItem onSelect={() => onDuplicate(item.id)}>
               Duplicate
             </DropdownMenuItem>
+            {onRegenerate && (
+              <DropdownMenuItem
+                data-testid={`slide-rail-regenerate-${item.id}`}
+                onSelect={() => onRegenerate(item.id)}
+              >
+                Regenerate text
+              </DropdownMenuItem>
+            )}
             <DropdownMenuItem
               onSelect={() => onRequestDelete(item.id)}
               className="text-red-500 focus:text-red-500"


### PR DESCRIPTION
Resolves the 7 bugs surfaced by the Studio→Pitch UI walkthrough (Epic #951). Single-PR batch — all changes scoped to `src/pitch/`, `src/api/pitch.ts`, `ui/app/pitch/`, `ui/components/pitch/`, and `CHANGELOG.md`.

## Bugs fixed

| # | Severity | Bug | Fix |
|---|----------|-----|-----|
| 1 | CRIT | Wizard aborted before LLM completed | `DRAFT_TIMEOUT_MS` 90s→240s; `[5,10,15,20]`→`[5,8,10,15,20]`; `wizard-progress` block with `aria-live="polite"`; `AbortError` distinguished from other errors. ([ui/app/pitch/new/page.tsx](ui/app/pitch/new/page.tsx)) |
| 2 | CRIT | Decktape spawn failure returned generic 500 | New `isPdfToolUnavailable(err)` helper checks `code` (`ENOENT`/`EACCES`/`ENOTDIR`) and message patterns. Both `/export.pdf` and `/export.notes.pdf` now return `503 { error: { code: "pdf_export_unavailable", message: "Decktape/Chromium failed to start. Run \`npx decktape --version\` to warm the cache." } }`. ([src/api/pitch.ts](src/api/pitch.ts)) |
| 3 | HIGH | Export button hard-coded disabled; no regenerate-text UI | Replaced disabled button with `DropdownMenu` of 5 formats (`pdf`/`pptx`/`md`/`notes`/`zip`). New `downloadExport()` helper handles auth + Content-Disposition. New `regenerateSlideMutation` POSTs to `/slides/:id/regenerate`. `SlideRail` exposes optional `onRegenerate` rendering a "Regenerate text" menu item. ([ui/app/pitch/[deckId]/page.tsx](ui/app/pitch/[deckId]/page.tsx), [ui/components/pitch/slide-rail.tsx](ui/components/pitch/slide-rail.tsx)) |
| 4 | MED | No per-slide speaker-notes editor | Added `<textarea data-testid="pitch-properties-speaker-notes">` to `PropertiesPanel`'s known-template branch; reuses existing 400ms debounced PATCH and rollback. ([ui/components/pitch/properties-panel.tsx](ui/components/pitch/properties-panel.tsx)) |
| 5 | MED | `targetSlideCount` ignored when model returned wrong count | `generateDeck` now tracks `lastError` (Zod) and `lastDeck` (count mismatch). Retry uses explicit prompt: `You returned N slides, but I asked for exactly T. Return EXACTLY T slides — no more, no fewer.` Falls back to `lastDeck` if retry also misses target. ([src/pitch/pitch-generator.ts](src/pitch/pitch-generator.ts)) |
| 6 | LOW | Regenerate-image dialog used stale prompt | Title editor passes `initialPrompt={slide.background_image_prompt ?? ""}`. Dialog adds `useEffect(() => { if (open) { setPrompt(initialPrompt); setError(null); } }, [open, initialPrompt])` since Radix keeps the dialog mounted while closed and `useState` only initialises once. ([ui/components/pitch/regenerate-image-dialog.tsx](ui/components/pitch/regenerate-image-dialog.tsx), [ui/components/pitch/property-editors/title.tsx](ui/components/pitch/property-editors/title.tsx)) |
| 7 | LOW | Dialogs missing `aria-describedby` | Added `<DialogDescription>` to `BrandKitEditor` and `RegenerateImageDialog`. ([ui/components/pitch/brand-kit-editor.tsx](ui/components/pitch/brand-kit-editor.tsx), [ui/components/pitch/regenerate-image-dialog.tsx](ui/components/pitch/regenerate-image-dialog.tsx)) |

## Tests

- **Backend** `src/pitch/pitch-generator.test.ts`: 2 new tests covering count-mismatch retry + graceful fallback when retry also misses.
- **Backend** `src/api/pitch.test.ts`: 1 new test injecting an `ENOENT`-shaped exporter rejection and asserting `503 pdf_export_unavailable` on both `/export.pdf` and `/export.notes.pdf`.
- **UI** `ui/components/pitch/properties-panel.test.tsx`: 1 new test verifying the speaker-notes textarea renders and PATCHes after debounce.
- **UI** `ui/app/pitch/[deckId]/page.test.tsx`: 2 new tests — (a) every export format renders in the menu, (b) clicking a format triggers `fetch` to the correct export URL.
- Updated `BrandKitEditor` and `RegenerateImageDialog` test mocks to expose `DialogDescription`.

All counts (full quality gate run on this branch):

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅ — 6972 tests pass
- `cd ui && pnpm test` ✅ — 639 tests pass
- `cd ui && pnpm exec next build` ✅ — clean build

## CHANGELOG

Entries added under `## [Unreleased]` — no version bump.

Closes #951 (walkthrough bug batch — does not close the epic itself)
