### PR TITLE
feat(pitch): AI-condense large script uploads up to 2 MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Pitch — AI-condensed large script uploads (up to 2 MB).** The Pitch wizard now accepts `.md` / `.txt` files up to 2 MB; oversize content is staged in a "Condense with AI" panel (explicit user click required — no auto-billing of LLM tokens) and run through a map-reduce summarisation pass before the existing `/decks/draft` pipeline. The persisted `source_script` cap stays at 50 KB — the condense step is the escape valve.
+- **New endpoint `POST /api/admin/pitch/script/condense`** (auth-gated through the `/api/admin/pitch` mount-point). 20 requests/hour/IP via a new `condenseLimiter`, audit-logged on success (`category: system, event: pitch.script.condensed`) and on 429 (`category: security, event: pitch.rate_limit_exceeded`). Per-route `express.json({ limit: "2.5mb" })` middleware (the global 1 MB parser skips this prefix in `src/app.ts` — every other pitch route keeps its 1 MB cap). Returns `413 { error: "script_too_large", maxBytes: 2_000_000 }` for over-ceiling input and `502 { error: "condense_failed", detail }` on LLM failure.
+
 ### Fixed (Epic #951 — Studio → Pitch Walkthrough Bug Batch)
 
 - Pitch deck draft no longer aborts before LLM completes (timeout raised to 240s, progress UI added).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6921,6 +6921,7 @@ flowchart LR
   UI[UI ui/app/pitch/*] -->|REST| Router[src/api/pitch.ts]
   Router --> Limiters[express-rate-limit per route]
   Limiters --> Schema[pitch-schema.ts Zod validation]
+  Schema --> Condense[pitch-condense.ts map-reduce summarizer]
   Schema --> Generator[pitch-generator.ts wrap+envelope+LLM]
   Schema --> Repo[pitch-repository.ts SQLite]
   Schema --> Image[pitch-image-service.ts Flux queue]
@@ -6930,11 +6931,23 @@ flowchart LR
   Sock --> UI
 ```
 
+### Condense endpoint (script pre-processing)
+
+`POST /api/admin/pitch/script/condense` accepts up to **2 MB** of raw script text (`.md`/`.txt` upload from the wizard) and returns text under the 50 KB `DraftDeckBodySchema.script` cap so it can be fed straight into the existing `/decks/draft` pipeline.
+
+- **Body parser:** the global 1 MB JSON parser in `src/app.ts` skips the `/api/admin/pitch/script/condense` prefix; the route mounts its own `express.json({ limit: "2.5mb" })` so other pitch routes keep their 1 MB cap (defence-in-depth against widening the global attack surface).
+- **Map-reduce:** input is split into ~30 000-character chunks on paragraph (`\n\n`) boundaries, each summarised by the Copilot LLM with a faithful-summary system prompt. If the concatenated summaries are still over the 40 KB target, a single reduce pass folds them into one script.
+- **Cost shape:** `chunks = ceil(originalChars / 30_000)`. A 459 KB input → ~16 map calls + (typically) 1 reduce call. Each call has a 1-retry budget on empty/malformed responses.
+- **Rate limit:** 20 / hour / IP (separate `condenseLimiter` built by the same `buildLimiter` factory; 429s emit the `pitch.rate_limit_exceeded` security audit event).
+- **Errors:** `413 { error: "script_too_large", maxBytes: 2_000_000 }` for over-ceiling input; `502 { error: "condense_failed", detail }` for LLM failures (stack never leaked).
+- **Audit:** `category: system, event: pitch.script.condensed` with `{ originalBytes, condensedBytes, chunks, targetBytes }`.
+
 ### Key components
 
 | File | Responsibility |
 |---|---|
 | `src/api/pitch.ts` | 24 routes, per-route rate-limit factory `buildLimiter(max, label)`, CSP on render/HTML export, 80-slide cap |
+| `src/pitch/pitch-condense.ts` | Map-reduce LLM summariser used by `POST /script/condense`. `condenseScript()` chunks raw text on paragraph boundaries, summarises each chunk via the Copilot wrapper, optionally runs a reduce pass to fit `targetBytes` (default 40 KB). 2 MB hard ceiling rejected before any LLM call. |
 | `src/pitch/pitch-schema.ts` | All Zod schemas. `BrandKitSchema`/`SlideImageSchema` URL fields are server-populated only |
 | `src/pitch/pitch-sanitize.ts` | Centralised DOMPurify; `sanitizeRichText/escapeHtml/escapeAttr/safeUrl`. Forbids `script`/`iframe`/`object`/`embed`/`link`/`meta`/`base`/`form`/`style` and all `on*`/`formaction`/`xlink:href`/`srcdoc`/`action`/`background`/`ping`/`style` attributes |
 | `src/pitch/pitch-utils.ts` | `wrapUserScript`: wraps user input in `<DATA>...</DATA>` envelope and strips any envelope tokens from the body |

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1873,6 +1873,18 @@ The **Pitch** workspace turns a script, brief, or research notes into a designed
 3. **Brand kits** — pick a starter kit (Modern Minimal, Corporate Blue, Vibrant Pitch, Editorial, Tech Dark, Warm Neutral) or create your own. Editable: heading + body fonts, accent colors, footer text, logo (≤ 2 MB PNG/JPEG/WebP). Logos are content-sniffed server-side.
 4. **Export** — five formats, all attachment downloads with `Cache-Control: no-store`:
 
+#### Large script uploads
+
+The persisted `source_script` field is capped at **50 KB** so the LLM draft pass stays cheap and the audit trail stays bounded. Real-world inputs (specs, user-guide markdown) are routinely 200 KB – 2 MB. The wizard handles this with an explicit AI condensation step:
+
+- The file picker / drag-and-drop accepts `.txt` / `.md` files up to **2 MB** (the hard ceiling).
+- Files ≤ 50 KB load directly into the script box.
+- Files between 50 KB and 2 MB stage a **Condense with AI** panel showing the file name, size, and an estimated `1 LLM call per ~30 KB` (a 459 KB user-guide → ~16 chunks, expect ~30s end-to-end). Click **Condense** to confirm — the wizard never auto-spends LLM tokens.
+- The condensed text drops into the textarea so you can review / edit before clicking Next. A small chip records the original → condensed sizes for transparency.
+- Files > 2 MB are rejected with a toast.
+
+The condense pipeline is map-reduce: each ~30 KB chunk is summarized with a faithful-summary prompt, then concatenated; if the concatenation is still over the 40 KB target, a single reduce pass folds the section summaries into one coherent script. The result is fed into the unchanged `/decks/draft` pipeline.
+
 | Format | Endpoint | Notes |
 |---|---|---|
 | PDF | `GET /api/admin/pitch/decks/:deckId/export.pdf` | Decktape subprocess, 60 s wall clock, abort on disconnect |
@@ -1890,6 +1902,7 @@ All Pitch routes are throttled per-IP with `express-rate-limit` (1 hour window, 
 | Action | Limit / hour |
 |---|---:|
 | Draft deck (`POST /decks/draft`) | 10 |
+| Condense oversize script (`POST /script/condense`) | 20 |
 | Regenerate slide | 60 |
 | Enhance text | 60 |
 | Enqueue slide image | 30 |

--- a/src/api/pitch.integration.test.ts
+++ b/src/api/pitch.integration.test.ts
@@ -49,6 +49,7 @@ const generateDeckMock = vi.fn();
 const regenerateSlideMock = vi.fn();
 const submitSlideRegenerateTaskMock = vi.fn();
 const enqueueSlideImageMock = vi.fn();
+const condenseScriptMock = vi.fn();
 
 vi.mock("../pitch/pitch-generator.js", () => ({
   generateDeck: (...a: unknown[]) => generateDeckMock(...a),
@@ -62,6 +63,16 @@ vi.mock("../pitch/pitch-regenerate.js", () => ({
 vi.mock("../pitch/pitch-image-service.js", () => ({
   enqueueSlideImage: (...a: unknown[]) => enqueueSlideImageMock(...a),
 }));
+vi.mock("../pitch/pitch-condense.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../pitch/pitch-condense.js")>(
+      "../pitch/pitch-condense.js",
+    );
+  return {
+    ...actual,
+    condenseScript: (...a: unknown[]) => condenseScriptMock(...a),
+  };
+});
 vi.mock("../logging/logger.js", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
@@ -184,7 +195,14 @@ function buildHarness(): Harness {
   };
 
   const app = express();
-  app.use(express.json());
+  // Mirror the production global JSON parser setup in `src/app.ts`: skip
+  // the global 1 MB parser for `/script/condense` so the route's own
+  // 2.5 MB body parser handles oversize uploads (the production server
+  // does the same thing via `skipGlobalParser`).
+  app.use((req, res, next) => {
+    if (req.path.startsWith("/api/admin/pitch/script/condense")) return next();
+    express.json({ limit: "1mb" })(req, res, next);
+  });
   app.use("/api/admin/pitch", createPitchRouter(deps));
 
   return {
@@ -240,6 +258,7 @@ describe("Pitch — Phase 7 integration (sub-issue #976)", () => {
     regenerateSlideMock.mockReset();
     submitSlideRegenerateTaskMock.mockReset();
     enqueueSlideImageMock.mockReset();
+    condenseScriptMock.mockReset();
     h = buildHarness();
   });
 
@@ -542,6 +561,118 @@ describe("Pitch — Phase 7 integration (sub-issue #976)", () => {
       expect(res.status).toBe(409);
       expect(res.body.error.code).toBe("conflict");
       expect(res.body.error.message).toMatch(/80/);
+    });
+  });
+
+  // ── /script/condense — AI map-reduce condensation endpoint ───────
+
+  describe("POST /script/condense (feat: AI script condensation)", () => {
+    it("happy path: 200 with { condensed, originalBytes, condensedBytes, chunks }", async () => {
+      // Stub the condense module to return a tiny summary so the test
+      // is fast and deterministic. The route still validates the body
+      // and shapes the response — that's what we're asserting here.
+      condenseScriptMock.mockResolvedValue({
+        condensed: "tiny summary",
+        originalBytes: 200_000,
+        condensedBytes: 12,
+        chunks: 7,
+      });
+      const text = "P".repeat(200_000);
+      const res = await request(h.app)
+        .post("/api/admin/pitch/script/condense")
+        .send({ text });
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        condensed: "tiny summary",
+        originalBytes: 200_000,
+        condensedBytes: 12,
+        chunks: 7,
+      });
+      expect(condenseScriptMock).toHaveBeenCalledTimes(1);
+      // Audit emitted with category=system + event=pitch.script.condensed.
+      const condenseAudits = h.auditLog.mock.calls.filter(
+        ([entry]) =>
+          (entry as { event?: string }).event === "pitch.script.condensed",
+      );
+      expect(condenseAudits.length).toBe(1);
+      expect(
+        (condenseAudits[0][0] as { details: Record<string, unknown> }).details,
+      ).toMatchObject({
+        originalBytes: 200_000,
+        condensedBytes: 12,
+        chunks: 7,
+      });
+    });
+
+    it("rejects > 2 MB with structured 413 envelope", async () => {
+      const oversize = "x".repeat(2_000_001);
+      const res = await request(h.app)
+        .post("/api/admin/pitch/script/condense")
+        .send({ text: oversize });
+      expect(res.status).toBe(413);
+      expect(res.body).toEqual({
+        error: "script_too_large",
+        maxBytes: 2_000_000,
+      });
+      expect(condenseScriptMock).not.toHaveBeenCalled();
+    });
+
+    it("returns 502 with structured envelope when LLM throws", async () => {
+      condenseScriptMock.mockRejectedValue(new Error("upstream LLM down"));
+      const res = await request(h.app)
+        .post("/api/admin/pitch/script/condense")
+        .send({ text: "x".repeat(60_000) });
+      expect(res.status).toBe(502);
+      expect(res.body).toEqual({
+        error: "condense_failed",
+        detail: "upstream LLM down",
+      });
+    });
+
+    it("rejects unknown body fields (Zod .strict())", async () => {
+      const res = await request(h.app)
+        .post("/api/admin/pitch/script/condense")
+        .send({ text: "ok", unknown: 1 });
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe("validation_error");
+    });
+
+    it("trips the 20/hr rate limiter and emits a security audit (PR #984)", async () => {
+      condenseScriptMock.mockResolvedValue({
+        condensed: "ok",
+        originalBytes: 5,
+        condensedBytes: 2,
+        chunks: 1,
+      });
+      // Drive to the cap.
+      for (let i = 0; i < 20; i++) {
+        const r = await request(h.app)
+          .post("/api/admin/pitch/script/condense")
+          .send({ text: "abc" });
+        expect(r.status).not.toBe(429);
+      }
+      h.auditLog.mockClear();
+      const tripped = await request(h.app)
+        .post("/api/admin/pitch/script/condense")
+        .send({ text: "abc" });
+      expect(tripped.status).toBe(429);
+      expect(tripped.body).toEqual({
+        error: { code: "rate_limited", message: expect.any(String) },
+      });
+      // The 429 emits a security-category audit event matching the
+      // existing pitch.rate_limit_exceeded shape.
+      const securityCalls = h.auditLog.mock.calls.filter(
+        ([entry]) =>
+          (entry as { category?: string }).category === "security" &&
+          (entry as { event?: string }).event === "pitch.rate_limit_exceeded",
+      );
+      expect(securityCalls.length).toBeGreaterThanOrEqual(1);
+      expect(
+        (securityCalls[0][0] as { details: Record<string, unknown> }).details,
+      ).toMatchObject({
+        route: expect.stringContaining("/script/condense"),
+        limit: 20,
+      });
     });
   });
 });

--- a/src/api/pitch.ts
+++ b/src/api/pitch.ts
@@ -26,6 +26,7 @@ import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { extname, join, resolve } from "node:path";
 import { Router, type Request, type Response } from "express";
+import express from "express";
 import multer from "multer";
 import { nanoid } from "nanoid";
 import rateLimit, { type RateLimitRequestHandler } from "express-rate-limit";
@@ -43,6 +44,11 @@ import {
   generateDeck,
   regenerateSlide,
 } from "../pitch/pitch-generator.js";
+import {
+  condenseScript,
+  CONDENSE_HARD_CEILING_BYTES,
+  DEFAULT_CONDENSE_TARGET_BYTES,
+} from "../pitch/pitch-condense.js";
 import { submitSlideRegenerateTask } from "../pitch/pitch-regenerate.js";
 import { enqueueSlideImage } from "../pitch/pitch-image-service.js";
 import { renderDeckToHtml } from "../pitch/pitch-renderer.js";
@@ -449,6 +455,7 @@ export function createPitchRouter(deps: PitchRouterDeps): Router {
   const htmlLimiter = buildLimiter(60, "HTML export");
   const notesLimiter = buildLimiter(20, "speaker-notes PDF");
   const crudLimiter = buildLimiter(600, "API");
+  const condenseLimiter = buildLimiter(20, "script condense");
 
   // ────────────────────────────────────────────────────────────────────
   // Deck CRUD (#959)
@@ -1070,6 +1077,97 @@ export function createPitchRouter(deps: PitchRouterDeps): Router {
   // ────────────────────────────────────────────────────────────────────
   // AI endpoints (#962)
   // ────────────────────────────────────────────────────────────────────
+
+  // ── POST /script/condense — AI map-reduce summarization ──────────
+  // Pre-processing escape valve for oversize script uploads (up to 2 MB).
+  // The persisted `source_script` cap stays at 50 KB; this route runs the
+  // raw input through `condenseScript` and returns text suitable for the
+  // existing `/decks/draft` pipeline.
+  //
+  // Body limit is bumped to 2.5 MB ON THIS ROUTE ONLY via per-route
+  // `express.json`; the global parser in `src/app.ts` skips this prefix
+  // (see `skipGlobalParser`). Do NOT widen the global limit — every other
+  // pitch route still uses the 1 MB cap.
+  const CondenseScriptBody = z
+    .object({
+      text: z.string().min(1).max(CONDENSE_HARD_CEILING_BYTES),
+      targetBytes: z.number().int().min(5_000).max(50_000).optional(),
+    })
+    .strict();
+
+  router.post(
+    "/script/condense",
+    condenseLimiter,
+    express.json({ limit: "2.5mb" }),
+    // Catch the body-parser's `entity.too.large` synchronously so the
+    // client gets a stable structured envelope instead of the default
+    // PayloadTooLargeError HTML page.
+    (
+      err: (Error & { type?: string; status?: number }) | null,
+      _req: Request,
+      res: Response,
+      next: (e?: unknown) => void,
+    ) => {
+      if (err && (err.type === "entity.too.large" || err.status === 413)) {
+        res
+          .status(413)
+          .json({ error: "script_too_large", maxBytes: CONDENSE_HARD_CEILING_BYTES });
+        return;
+      }
+      next(err ?? undefined);
+    },
+    async (req: Request, res: Response) => {
+      const parsed = CondenseScriptBody.safeParse(req.body);
+      if (!parsed.success) {
+        // The Zod `max()` rejection for an oversize text field is also a
+        // 413 (semantically a payload-too-large), not a 400.
+        const tooLarge = parsed.error.issues.some(
+          (i) => i.path[0] === "text" && i.code === "too_big",
+        );
+        if (tooLarge) {
+          res
+            .status(413)
+            .json({ error: "script_too_large", maxBytes: CONDENSE_HARD_CEILING_BYTES });
+          return;
+        }
+        sendError(res, 400, "validation_error", "Request body failed validation", {
+          issues: parsed.error.issues.map((i) => ({
+            path: i.path.join("."),
+            message: i.message,
+            code: i.code,
+          })),
+        });
+        return;
+      }
+      const body = parsed.data;
+      const targetBytes = body.targetBytes ?? DEFAULT_CONDENSE_TARGET_BYTES;
+
+      try {
+        const result = await condenseScript(body.text, deps.copilot, {
+          targetBytes,
+        });
+        audit("system", "pitch.script.condensed", {
+          originalBytes: result.originalBytes,
+          condensedBytes: result.condensedBytes,
+          chunks: result.chunks,
+          targetBytes,
+        });
+        res.status(200).json(result);
+      } catch (err) {
+        const detail = errMessage(err);
+        // The hard-ceiling guard inside `condenseScript` is also reachable
+        // here if the per-route body parser somehow let through > 2 MB.
+        if (/hard ceiling/i.test(detail)) {
+          res
+            .status(413)
+            .json({ error: "script_too_large", maxBytes: CONDENSE_HARD_CEILING_BYTES });
+          return;
+        }
+        logger.error(`[Pitch API] POST /script/condense failed: ${detail}`);
+        res.status(502).json({ error: "condense_failed", detail });
+      }
+    },
+  );
 
   router.post("/decks/draft", draftLimiter, async (req, res) => {
     const body = parseBody(DraftDeckBody, res, req);

--- a/src/app.ts
+++ b/src/app.ts
@@ -223,7 +223,11 @@ export const createApp = (
   const skipGlobalParser = (p: string) =>
     p.startsWith("/api/queue") ||
     p.startsWith("/api/social/webhooks") ||
-    p.startsWith("/api/admin/creative/enhance-prompt");
+    p.startsWith("/api/admin/creative/enhance-prompt") ||
+    // /api/admin/pitch/script/condense accepts up to 2 MB of raw script
+    // text; the global 1 MB parser would 413 before the route's own
+    // express.json({ limit: "2.5mb" }) middleware can run.
+    p.startsWith("/api/admin/pitch/script/condense");
   app.use((req, res, next) => {
     if (skipGlobalParser(req.path)) return next();
     express.json({ limit: "1mb" })(req, res, next);

--- a/src/pitch/pitch-condense.test.ts
+++ b/src/pitch/pitch-condense.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Pitch — `pitch-condense` unit tests.
+ *
+ * Covers:
+ *   - under-cap passthrough makes ZERO LLM calls (cost discipline);
+ *   - single-chunk condense calls the LLM once;
+ *   - multi-chunk map-reduce with no reduce stage when concat fits;
+ *   - reduce stage triggers when concat is still over target;
+ *   - 2 MB hard ceiling rejection BEFORE any LLM call;
+ *   - retry-on-empty: empty first response → second attempt succeeds;
+ *   - both attempts empty → throws.
+ *
+ * The Copilot wrapper is mocked with `vi.fn()` returning canned async
+ * iterators so the test never touches a real model.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  condenseScript,
+  splitIntoChunks,
+  CONDENSE_HARD_CEILING_BYTES,
+  DEFAULT_CONDENSE_TARGET_BYTES,
+  CONDENSE_CHUNK_CHARS,
+} from "./pitch-condense.js";
+import type { CopilotWrapper } from "../copilot/copilot-wrapper.js";
+
+vi.mock("../logging/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+/** Build an async-iterable that yields the given chunks one by one. */
+function streamOf(...chunks: string[]): AsyncIterable<string> {
+  return (async function* () {
+    for (const c of chunks) yield c;
+  })();
+}
+
+/** Build a fake CopilotWrapper whose `.chat()` returns canned outputs in
+ *  call order. The Nth invocation yields `outputs[N]` as a single chunk. */
+function fakeCopilot(outputs: string[]): {
+  copilot: CopilotWrapper;
+  chat: ReturnType<typeof vi.fn>;
+} {
+  let i = 0;
+  const chat = vi.fn().mockImplementation(() => {
+    const out = outputs[i] ?? "";
+    i += 1;
+    return streamOf(out);
+  });
+  return {
+    copilot: { chat } as unknown as CopilotWrapper,
+    chat,
+  };
+}
+
+describe("splitIntoChunks", () => {
+  it("returns the input unchanged when under the limit", () => {
+    expect(splitIntoChunks("short", 100)).toEqual(["short"]);
+  });
+
+  it("prefers paragraph (\\n\\n) boundaries", () => {
+    const text = ["A".repeat(40), "B".repeat(40), "C".repeat(40)].join("\n\n");
+    const parts = splitIntoChunks(text, 90);
+    expect(parts.length).toBeGreaterThanOrEqual(2);
+    // No part should exceed the cap by more than a small margin (we always
+    // cut at <= maxChars, then trim trailing whitespace).
+    for (const p of parts) expect(p.length).toBeLessThanOrEqual(90);
+  });
+
+  it("falls back to line boundaries, then hard cut", () => {
+    const text = "X".repeat(250);
+    const parts = splitIntoChunks(text, 100);
+    expect(parts.length).toBe(3);
+    expect(parts.every((p) => p.length <= 100)).toBe(true);
+  });
+
+  it("rejects non-positive maxChars", () => {
+    expect(() => splitIntoChunks("x", 0)).toThrow();
+  });
+});
+
+describe("condenseScript", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passthrough: makes ZERO LLM calls when input is already under target", async () => {
+    const { copilot, chat } = fakeCopilot([]);
+    const result = await condenseScript("a small script", copilot);
+    expect(chat).not.toHaveBeenCalled();
+    expect(result.chunks).toBe(0);
+    expect(result.condensed).toBe("a small script");
+    expect(result.originalBytes).toBe(result.condensedBytes);
+  });
+
+  it("single-chunk condense: 1 LLM call, returns the summary", async () => {
+    // Build text just over the (small) target so we trigger the map path
+    // but only generate a single chunk.
+    const text = "P".repeat(50);
+    const { copilot, chat } = fakeCopilot(["short summary"]);
+    const result = await condenseScript(text, copilot, { targetBytes: 30 });
+    expect(chat).toHaveBeenCalledTimes(1);
+    expect(result.chunks).toBe(1);
+    expect(result.condensed).toBe("short summary");
+    expect(result.condensedBytes).toBeLessThan(result.originalBytes);
+  });
+
+  it("multi-chunk map: N LLM calls, no reduce when concat fits target", async () => {
+    // 3 paragraph blocks ~20k chars each (well under the 30k chunk cap),
+    // separated by `\n\n` so the splitter cleanly produces exactly 3
+    // chunks. Summaries are short so concat stays under the target and
+    // the reduce stage does NOT run.
+    const para = (label: string): string => `${label}\n\n` + "X".repeat(20_000);
+    const text = [para("A"), para("B"), para("C")].join("\n\n");
+    const { copilot, chat } = fakeCopilot([
+      "summary A",
+      "summary B",
+      "summary C",
+    ]);
+    const result = await condenseScript(text, copilot, {
+      targetBytes: 1_000,
+    });
+    expect(chat).toHaveBeenCalledTimes(3);
+    expect(result.chunks).toBe(3);
+    expect(result.condensed).toContain("summary A");
+    expect(result.condensed).toContain("summary B");
+    expect(result.condensed).toContain("summary C");
+  });
+
+  it("reduce stage runs when map concat is still over target", async () => {
+    // 2 chunks, each summary is large enough that concat > target.
+    const text = "X".repeat(CONDENSE_CHUNK_CHARS) + "\n\n" + "Y".repeat(CONDENSE_CHUNK_CHARS);
+    const bigSummary = "Z".repeat(800);
+    const { copilot, chat } = fakeCopilot([
+      bigSummary, // map 1
+      bigSummary, // map 2
+      "final reduced script", // reduce
+    ]);
+    const result = await condenseScript(text, copilot, { targetBytes: 1_000 });
+    expect(chat).toHaveBeenCalledTimes(3);
+    expect(result.chunks).toBe(2);
+    expect(result.condensed).toBe("final reduced script");
+  });
+
+  it("rejects empty input", async () => {
+    const { copilot } = fakeCopilot([]);
+    await expect(condenseScript("", copilot)).rejects.toThrow(/empty/i);
+  });
+
+  it("rejects input over the 2 MB hard ceiling BEFORE any LLM call", async () => {
+    const oversize = "x".repeat(CONDENSE_HARD_CEILING_BYTES + 1);
+    const { copilot, chat } = fakeCopilot([]);
+    await expect(condenseScript(oversize, copilot)).rejects.toThrow(
+      /hard ceiling/i,
+    );
+    expect(chat).not.toHaveBeenCalled();
+  });
+
+  it("retries once on empty LLM response, then succeeds", async () => {
+    const text = "P".repeat(50);
+    const { copilot, chat } = fakeCopilot(["", "recovered summary"]);
+    const result = await condenseScript(text, copilot, { targetBytes: 30 });
+    expect(chat).toHaveBeenCalledTimes(2);
+    expect(result.condensed).toBe("recovered summary");
+  });
+
+  it("throws when both attempts return empty", async () => {
+    const text = "P".repeat(50);
+    const { copilot, chat } = fakeCopilot(["", ""]);
+    await expect(
+      condenseScript(text, copilot, { targetBytes: 30 }),
+    ).rejects.toThrow(/empty/i);
+    expect(chat).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses the default target when none is provided", async () => {
+    // Just over default; the splitter will produce 2 chunks at the
+    // CONDENSE_CHUNK_CHARS boundary. Provide enough canned outputs to
+    // cover the worst case and assert via call-count + chunks.
+    const text = "Q".repeat(DEFAULT_CONDENSE_TARGET_BYTES + 100);
+    const { copilot, chat } = fakeCopilot(Array(10).fill("ok"));
+    const result = await condenseScript(text, copilot);
+    expect(chat).toHaveBeenCalled();
+    expect(result.chunks).toBeGreaterThan(0);
+    expect(result.originalBytes).toBe(text.length);
+  });
+});

--- a/src/pitch/pitch-condense.ts
+++ b/src/pitch/pitch-condense.ts
@@ -1,0 +1,240 @@
+/**
+ * Pitch — AI script condensation (map-reduce summarization).
+ *
+ * The Pitch wizard caps the persisted `source_script` at 50 KB so the LLM
+ * draft pass stays cheap and the audit-trail metadata stays bounded.
+ * Real-world inputs (specs, user-guide markdown) are routinely 200 KB – 2 MB.
+ * This module is the escape valve: it accepts oversize raw text, splits it
+ * into ~30 KB chunks on paragraph boundaries, summarizes each chunk via
+ * the Copilot LLM with a faithful-summary system prompt, then concatenates
+ * the summaries. If the concatenation is still over the target, a single
+ * reduce pass is run to fold the section summaries into one coherent
+ * script under the cap.
+ *
+ * Hard rules:
+ *   - Inputs already ≤ targetBytes pass through with ZERO LLM calls.
+ *   - Inputs > {@link CONDENSE_HARD_CEILING_BYTES} are rejected before
+ *     any LLM call (denial-of-wallet defence).
+ *   - Each LLM call gets ONE retry on empty/malformed response, mirroring
+ *     the per-call retry budget used by `pitch-generator.ts`.
+ *   - No streaming — full response collected per call (`accumulateStream`).
+ *
+ * Lives in its own module so the unit tests can mock the Copilot wrapper
+ * with `vi.fn()` returning canned summaries without dragging in the deck
+ * generator's prompt builders.
+ */
+import type { CopilotWrapper } from "../copilot/copilot-wrapper.js";
+import { logger } from "../logging/logger.js";
+import { accumulateStream } from "./pitch-utils.js";
+
+/** Default condensed-output target. Leaves headroom under the 50 KB
+ *  `source_script` cap enforced by `DraftDeckBodySchema`. */
+export const DEFAULT_CONDENSE_TARGET_BYTES = 40_000;
+
+/** Hard ceiling on raw input bytes — rejected before any LLM call.
+ *  Mirrors the file-picker cap on the wizard. */
+export const CONDENSE_HARD_CEILING_BYTES = 2_000_000;
+
+/** Approximate per-chunk size in characters. Chosen so each map call
+ *  stays well within model context windows and LLM cost is predictable
+ *  (a 459 KB input → ~16 chunks → 16 + 1 reduce LLM calls). */
+export const CONDENSE_CHUNK_CHARS = 30_000;
+
+/** Agent name used on the Copilot wrapper call. */
+const CONDENSE_AGENT_NAME = "pitch-condense";
+
+const MAP_SYSTEM_PROMPT =
+  "You are condensing a section of a longer document into a faithful, structured summary that will be used to author a presentation. Preserve all proper nouns, numbers, claims, and section structure. Output plain prose / bullet sections. Do NOT add commentary.";
+
+const REDUCE_SYSTEM_PROMPT_PREFIX =
+  "You are combining section summaries into a single coherent script that will be used to author a presentation. Preserve all proper nouns, numbers, claims, and section structure. Output plain prose / bullet sections. Do NOT add commentary.";
+
+export interface CondenseScriptOpts {
+  /** Target output size in bytes. Defaults to {@link DEFAULT_CONDENSE_TARGET_BYTES}. */
+  targetBytes?: number;
+  /** Optional injectable clock for deterministic logging in tests. */
+  clock?: () => Date;
+  /** Optional model override. Falls back to the wrapper default. */
+  model?: string;
+  /** Optional cached SDK session id, mirroring `pitch-generator.ts`. */
+  sessionId?: string;
+}
+
+export interface CondenseScriptResult {
+  /** Condensed text safe to feed into the existing draft pipeline. */
+  condensed: string;
+  /** Raw input length in UTF-8 bytes. */
+  originalBytes: number;
+  /** Output length in UTF-8 bytes. */
+  condensedBytes: number;
+  /** Number of map-stage LLM calls made. `0` when the input was already
+   *  under the target and we passed it through unchanged. */
+  chunks: number;
+}
+
+/**
+ * Condense `rawText` down to ≤ targetBytes via map-reduce LLM summarization.
+ *
+ * Throws when:
+ *   - `rawText` is empty (caller error — the endpoint validates `min(1)`).
+ *   - `rawText` exceeds {@link CONDENSE_HARD_CEILING_BYTES} (no LLM call made).
+ *   - the LLM returns an empty string twice in a row for a single chunk.
+ */
+export async function condenseScript(
+  rawText: string,
+  copilot: CopilotWrapper,
+  opts: CondenseScriptOpts = {},
+): Promise<CondenseScriptResult> {
+  const text = String(rawText ?? "");
+  const originalBytes = Buffer.byteLength(text, "utf8");
+  if (originalBytes === 0) {
+    throw new Error("pitch-condense: rawText is empty");
+  }
+  if (originalBytes > CONDENSE_HARD_CEILING_BYTES) {
+    throw new Error(
+      `pitch-condense: rawText exceeds ${CONDENSE_HARD_CEILING_BYTES.toLocaleString()} byte hard ceiling`,
+    );
+  }
+
+  const targetBytes = opts.targetBytes ?? DEFAULT_CONDENSE_TARGET_BYTES;
+
+  // Fast path — already small enough, no LLM call.
+  if (originalBytes <= targetBytes) {
+    return {
+      condensed: text,
+      originalBytes,
+      condensedBytes: originalBytes,
+      chunks: 0,
+    };
+  }
+
+  // ── Map stage ────────────────────────────────────────────────────
+  const chunks = splitIntoChunks(text, CONDENSE_CHUNK_CHARS);
+  logger.info(
+    `[pitch-condense] map stage: ${chunks.length} chunks, originalBytes=${originalBytes}, targetBytes=${targetBytes}`,
+  );
+
+  const summaries: string[] = [];
+  for (let i = 0; i < chunks.length; i++) {
+    const userPrompt = buildMapUserPrompt(chunks[i], i + 1, chunks.length);
+    const summary = await callLLMWithRetry(
+      copilot,
+      userPrompt,
+      MAP_SYSTEM_PROMPT,
+      opts,
+    );
+    summaries.push(summary);
+  }
+
+  let condensed = summaries.join("\n\n");
+  let condensedBytes = Buffer.byteLength(condensed, "utf8");
+
+  // ── Reduce stage (only if concat is still over target) ───────────
+  if (condensedBytes > targetBytes) {
+    logger.info(
+      `[pitch-condense] reduce stage triggered: concatBytes=${condensedBytes}, targetBytes=${targetBytes}`,
+    );
+    const targetWords = Math.max(200, Math.floor(targetBytes / 6));
+    const reduceSystemPrompt = `${REDUCE_SYSTEM_PROMPT_PREFIX} Hard cap: ${targetWords} words.`;
+    const reduceUserPrompt = [
+      `Combine these ${summaries.length} section summaries into a single coherent script of at most ${targetWords} words. Preserve all key facts, proper nouns, and numbers.`,
+      "",
+      condensed,
+    ].join("\n");
+    condensed = await callLLMWithRetry(
+      copilot,
+      reduceUserPrompt,
+      reduceSystemPrompt,
+      opts,
+    );
+    condensedBytes = Buffer.byteLength(condensed, "utf8");
+  }
+
+  return {
+    condensed,
+    originalBytes,
+    condensedBytes,
+    chunks: chunks.length,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// internals
+// ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Split `text` into chunks of approximately `maxChars` characters,
+ * preferring paragraph (`\n\n`) boundaries, then line (`\n`) boundaries,
+ * then a hard cut. Never returns empty chunks.
+ */
+export function splitIntoChunks(text: string, maxChars: number): string[] {
+  if (maxChars <= 0) {
+    throw new Error("pitch-condense: maxChars must be > 0");
+  }
+  if (text.length <= maxChars) return [text];
+
+  const out: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > maxChars) {
+    const window = remaining.slice(0, maxChars);
+    let cut = window.lastIndexOf("\n\n");
+    if (cut < Math.floor(maxChars / 2)) cut = window.lastIndexOf("\n");
+    if (cut < Math.floor(maxChars / 2)) cut = maxChars; // hard cut
+    const head = remaining.slice(0, cut).trim();
+    if (head.length > 0) out.push(head);
+    remaining = remaining.slice(cut).replace(/^\s+/, "");
+  }
+  if (remaining.trim().length > 0) out.push(remaining.trim());
+  return out;
+}
+
+function buildMapUserPrompt(
+  chunk: string,
+  index: number,
+  total: number,
+): string {
+  return [
+    `Condense the following section (${index} of ${total}) into a faithful summary suitable for use as presentation source material.`,
+    "",
+    "<DOCUMENT_SECTION>",
+    chunk,
+    "</DOCUMENT_SECTION>",
+  ].join("\n");
+}
+
+async function callLLMWithRetry(
+  copilot: CopilotWrapper,
+  userPrompt: string,
+  systemPrompt: string,
+  opts: CondenseScriptOpts,
+): Promise<string> {
+  // Initial attempt + 1 retry on empty/whitespace response. Same retry
+  // budget shape as `pitch-generator.ts`.
+  let lastError: unknown = null;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const stream = copilot.chat(userPrompt, {
+        tools: [],
+        ...(opts.model ? { model: opts.model } : {}),
+        ...(opts.sessionId ? { conversationId: opts.sessionId } : {}),
+        systemMessage: { mode: "replace", content: systemPrompt },
+        agent: CONDENSE_AGENT_NAME,
+      } as Parameters<CopilotWrapper["chat"]>[1]);
+      const raw = await accumulateStream(stream);
+      const cleaned = raw.trim();
+      if (cleaned.length === 0) {
+        throw new Error("pitch-condense: model returned empty output");
+      }
+      return cleaned;
+    } catch (err) {
+      lastError = err;
+      logger.warn(
+        `[pitch-condense] LLM attempt ${attempt + 1} failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("pitch-condense: LLM call failed");
+}

--- a/ui/app/pitch/new/page.test.tsx
+++ b/ui/app/pitch/new/page.test.tsx
@@ -173,4 +173,123 @@ describe("NewPitchDeckPage wizard", () => {
     const body = JSON.parse(String((init as RequestInit).body));
     expect(body.options.tone).toBe("sales");
   });
+
+  // ── AI script condensation (feat: 2 MB upload + condense flow) ──
+
+  describe("AI script condensation", () => {
+    /** Drive the wizard to the script step. */
+    async function gotoScriptStep() {
+      render(<NewPitchDeckPage />, { wrapper });
+      await waitFor(() => screen.getByTestId("wizard-kit-kit-a"));
+      fireEvent.click(screen.getByTestId("wizard-kit-kit-a"));
+      fireEvent.click(screen.getByTestId("wizard-next"));
+    }
+
+    it("shows the condense panel when a > 50 KB file is dropped", async () => {
+      await gotoScriptStep();
+      const big = "X".repeat(200_000);
+      const file = new File([big], "big.md", { type: "text/markdown" });
+      const dropzone = screen.getByTestId("wizard-dropzone");
+      fireEvent.drop(dropzone, {
+        dataTransfer: { files: [file] },
+      });
+      await waitFor(() =>
+        expect(
+          screen.getByTestId("wizard-condense-panel"),
+        ).toBeInTheDocument(),
+      );
+      expect(screen.getByTestId("wizard-condense-filename")).toHaveTextContent(
+        "big.md",
+      );
+      // 200 KB → "200.0 KB" displayed.
+      expect(screen.getByTestId("wizard-condense-bytes")).toHaveTextContent(
+        /200\.0 KB/,
+      );
+      // The textarea must NOT be auto-populated — explicit click required.
+      expect(screen.getByTestId("wizard-script-textarea")).toHaveValue("");
+    });
+
+    it("posts to /script/condense and populates the textarea on confirm", async () => {
+      // Override the default fetch mock for this test to return a
+      // condensation envelope.
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: async () => "{}",
+        json: async () => ({
+          condensed: "tiny condensed summary",
+          originalBytes: 200_000,
+          condensedBytes: 22,
+          chunks: 7,
+        }),
+      }) as unknown as typeof fetch;
+
+      await gotoScriptStep();
+      const big = "X".repeat(200_000);
+      const file = new File([big], "spec.md", { type: "text/markdown" });
+      fireEvent.drop(screen.getByTestId("wizard-dropzone"), {
+        dataTransfer: { files: [file] },
+      });
+      await waitFor(() =>
+        expect(
+          screen.getByTestId("wizard-condense-confirm"),
+        ).toBeInTheDocument(),
+      );
+
+      fireEvent.click(screen.getByTestId("wizard-condense-confirm"));
+
+      await waitFor(() =>
+        expect(screen.getByTestId("wizard-script-textarea")).toHaveValue(
+          "tiny condensed summary",
+        ),
+      );
+      // Chip with original/condensed sizes.
+      expect(screen.getByTestId("wizard-condense-chip")).toBeInTheDocument();
+      // The condense panel disappears once the request succeeds.
+      expect(screen.queryByTestId("wizard-condense-panel")).toBeNull();
+
+      const fetchCalls = (
+        global.fetch as unknown as { mock: { calls: unknown[][] } }
+      ).mock.calls;
+      const [url, init] = fetchCalls[0]!;
+      expect(String(url)).toContain("/api/admin/pitch/script/condense");
+      expect((init as RequestInit).method).toBe("POST");
+      const body = JSON.parse(String((init as RequestInit).body));
+      expect(body).toEqual({ text: big });
+    });
+
+    it("rejects > 2 MB file with a toast and no fetch", async () => {
+      const { showToast } = await import("@/components/toast");
+      vi.mocked(showToast).mockClear();
+
+      await gotoScriptStep();
+      const oversize = "X".repeat(2_000_001);
+      const file = new File([oversize], "huge.md", {
+        type: "text/markdown",
+      });
+      fireEvent.drop(screen.getByTestId("wizard-dropzone"), {
+        dataTransfer: { files: [file] },
+      });
+      await waitFor(() =>
+        expect(vi.mocked(showToast)).toHaveBeenCalled(),
+      );
+      // No condense panel; no POST issued.
+      expect(screen.queryByTestId("wizard-condense-panel")).toBeNull();
+    });
+
+    it("does NOT show the condense panel when a small file is dropped", async () => {
+      await gotoScriptStep();
+      const small = "small content";
+      const file = new File([small], "small.md", { type: "text/markdown" });
+      fireEvent.drop(screen.getByTestId("wizard-dropzone"), {
+        dataTransfer: { files: [file] },
+      });
+      await waitFor(() =>
+        expect(screen.getByTestId("wizard-script-textarea")).toHaveValue(
+          small,
+        ),
+      );
+      expect(screen.queryByTestId("wizard-condense-panel")).toBeNull();
+    });
+  });
 });

--- a/ui/app/pitch/new/page.tsx
+++ b/ui/app/pitch/new/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useRef, useState, type ClipboardEvent } from "react";
 import { useRouter } from "next/navigation";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { fetchJson, buildUrl } from "@/lib/api";
@@ -17,6 +17,15 @@ interface BrandKitsResponse {
 }
 
 const SCRIPT_BYTE_CAP = 50_000;
+// Hard cap on raw file uploads / oversize content fed into the AI
+// condensation endpoint (`POST /api/admin/pitch/script/condense`). This
+// MUST stay in sync with `CONDENSE_HARD_CEILING_BYTES` in
+// `src/pitch/pitch-condense.ts` — the backend rejects > 2 MB with 413.
+const FILE_BYTE_CAP = 2_000_000;
+// Direct-paste cap on the textarea. We let users paste up to 200 KB
+// without hitting the file-drop flow; anything above the script cap but
+// under this still triggers the "Condense with AI" panel.
+const RAW_PASTE_BYTE_CAP = 200_000;
 const DRAFT_TIMEOUT_MS = 240_000;
 
 const AUTH_TOKEN =
@@ -50,6 +59,17 @@ export default function NewPitchDeckPage() {
   const [tone, setTone] = useState<Tone>("formal");
   const [submitting, setSubmitting] = useState(false);
   const [createKitOpen, setCreateKitOpen] = useState(false);
+  // Condense panel state — set when the user drops/pastes content over
+  // the 50 KB draft cap but under the 2 MB hard ceiling. The user must
+  // explicitly click "Condense" (LLM cost transparency — we never
+  // auto-bill them tokens).
+  const [pendingCondense, setPendingCondense] = useState<
+    { name: string; bytes: number; text: string } | null
+  >(null);
+  const [condensing, setCondensing] = useState(false);
+  const [condenseInfo, setCondenseInfo] = useState<
+    { originalBytes: number; condensedBytes: number; chunks: number } | null
+  >(null);
   const queryClient = useQueryClient();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -76,12 +96,100 @@ export default function NewPitchDeckPage() {
       showToast("Only .txt or .md files are accepted.", "error");
       return;
     }
-    if (file.size > SCRIPT_BYTE_CAP) {
-      showToast("Script exceeds the 50 KB cap.", "error");
+    if (file.size > FILE_BYTE_CAP) {
+      showToast(
+        `File exceeds the ${(FILE_BYTE_CAP / 1_000_000).toFixed(0)} MB hard cap.`,
+        "error",
+      );
       return;
     }
     const text = await file.text();
-    setScript(text);
+    const bytes = new Blob([text]).size;
+    if (bytes <= SCRIPT_BYTE_CAP) {
+      // Small enough to use directly — no LLM call needed.
+      setScript(text);
+      setPendingCondense(null);
+      setCondenseInfo(null);
+      return;
+    }
+    // Over the draft cap but under the hard ceiling — stage for explicit
+    // user-confirmed condensation.
+    setPendingCondense({ name: file.name, bytes, text });
+    setCondenseInfo(null);
+  };
+
+  const handleCondense = async () => {
+    if (!pendingCondense) return;
+    setCondensing(true);
+    try {
+      const url = buildUrl("/api/admin/pitch/script/condense");
+      const headers: HeadersInit = { "Content-Type": "application/json" };
+      if (AUTH_TOKEN) headers["Authorization"] = `Bearer ${AUTH_TOKEN}`;
+      const res = await fetch(url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ text: pendingCondense.text }),
+      });
+      if (res.status === 413) {
+        showToast("File exceeds 2 MB hard cap.", "error");
+        return;
+      }
+      if (!res.ok) {
+        let detail = `HTTP ${res.status}`;
+        try {
+          const body = (await res.json()) as {
+            detail?: string;
+            error?: { message?: string } | string;
+          };
+          if (body?.detail) detail = body.detail;
+          else if (typeof body?.error === "string") detail = body.error;
+          else if (body?.error && typeof body.error === "object" && body.error.message)
+            detail = body.error.message;
+        } catch {
+          /* fall through */
+        }
+        showToast(`Could not condense script: ${detail}`, "error");
+        return;
+      }
+      const data = (await res.json()) as {
+        condensed: string;
+        originalBytes: number;
+        condensedBytes: number;
+        chunks: number;
+      };
+      setScript(data.condensed);
+      setCondenseInfo({
+        originalBytes: data.originalBytes,
+        condensedBytes: data.condensedBytes,
+        chunks: data.chunks,
+      });
+      setPendingCondense(null);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      showToast(`Could not condense script: ${msg}`, "error");
+    } finally {
+      setCondensing(false);
+    }
+  };
+
+  const handlePaste = (e: ClipboardEvent<HTMLTextAreaElement>) => {
+    const pasted = e.clipboardData.getData("text");
+    if (!pasted) return;
+    const bytes = new Blob([pasted]).size;
+    // Only intercept oversize pastes — below RAW_PASTE_BYTE_CAP we let
+    // the textarea handle it normally.
+    if (bytes <= RAW_PASTE_BYTE_CAP) return;
+    if (bytes > FILE_BYTE_CAP) {
+      e.preventDefault();
+      showToast(
+        `Pasted content exceeds the ${(FILE_BYTE_CAP / 1_000_000).toFixed(0)} MB hard cap.`,
+        "error",
+      );
+      return;
+    }
+    e.preventDefault();
+    setPendingCondense({ name: "clipboard.txt", bytes, text: pasted });
+    setCondenseInfo(null);
   };
 
   const handleSubmit = async () => {
@@ -216,7 +324,8 @@ export default function NewPitchDeckPage() {
           <div data-testid="wizard-step-script">
             <h2 className="text-sm font-semibold">Provide your script</h2>
             <p className="mb-3 text-xs text-muted-foreground">
-              Paste up to 50 KB of text or drop a `.txt`/`.md` file.
+              Paste up to 50 KB, or drop a `.txt`/`.md` file up to 2 MB and we&apos;ll
+              condense it with AI.
             </p>
             <div
               data-testid="wizard-dropzone"
@@ -248,10 +357,76 @@ export default function NewPitchDeckPage() {
                 }}
               />
             </div>
+            {pendingCondense && (
+              <div
+                data-testid="wizard-condense-panel"
+                role="region"
+                aria-label="Condense oversize script with AI"
+                className="mb-2 rounded border border-primary/40 bg-primary/5 p-3 text-xs"
+              >
+                <div className="font-semibold text-foreground">
+                  AI condense required
+                </div>
+                <div className="mt-1 text-muted-foreground">
+                  <span data-testid="wizard-condense-filename">
+                    {pendingCondense.name}
+                  </span>{" "}
+                  &mdash;{" "}
+                  <span data-testid="wizard-condense-bytes">
+                    {(pendingCondense.bytes / 1000).toFixed(1)} KB
+                  </span>
+                  . Exceeds the 50 KB draft cap.
+                </div>
+                <div className="mt-1 text-muted-foreground">
+                  Condense (uses ~30s and 1 LLM call per ~30 KB).
+                </div>
+                <div className="mt-2 flex gap-2">
+                  <button
+                    type="button"
+                    data-testid="wizard-condense-confirm"
+                    onClick={handleCondense}
+                    disabled={condensing}
+                    className="inline-flex items-center gap-2 rounded bg-primary px-3 py-1 text-xs font-semibold text-primary-foreground disabled:opacity-50"
+                  >
+                    {condensing && (
+                      <span
+                        data-testid="wizard-condense-spinner"
+                        className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent"
+                      />
+                    )}
+                    {condensing
+                      ? `Condensing ${(pendingCondense.bytes / 1000).toFixed(1)} KB script — ${Math.max(
+                          1,
+                          Math.ceil(pendingCondense.bytes / 30_000),
+                        )} chunks…`
+                      : "Condense with AI"}
+                  </button>
+                  <button
+                    type="button"
+                    data-testid="wizard-condense-cancel"
+                    onClick={() => setPendingCondense(null)}
+                    disabled={condensing}
+                    className="rounded border border-border px-3 py-1 text-xs disabled:opacity-50"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
+            {condenseInfo && (
+              <div
+                data-testid="wizard-condense-chip"
+                className="mb-2 inline-flex items-center rounded-full border border-primary/40 bg-primary/10 px-2 py-0.5 text-[11px] text-foreground"
+              >
+                Condensed from {(condenseInfo.originalBytes / 1000).toFixed(1)} KB
+                → {(condenseInfo.condensedBytes / 1000).toFixed(1)} KB via AI
+              </div>
+            )}
             <textarea
               data-testid="wizard-script-textarea"
               value={script}
               onChange={(e) => setScript(e.target.value)}
+              onPaste={handlePaste}
               placeholder="Paste your script…"
               className="h-48 w-full resize-y rounded border border-border bg-background p-2 text-sm"
             />


### PR DESCRIPTION
﻿## Summary

Implements **AI-powered script condensation** for the Studio → Pitch wizard so users can upload large `.md` / `.txt` files (up to 2 MB) instead of being blocked by the hard 50 KB cap.

The persisted `source_script` cap (50 KB) is **not** raised — condensation is the escape valve for big inputs. The wizard **never auto-condenses**: oversize uploads stage a "Condense with AI" prompt panel and require an explicit user click before any LLM token is spent.

## Endpoint

`POST /api/admin/pitch/script/condense`

- Auth-gated by the `/api/admin/pitch` mount.
- 20 requests / hour / IP via a new `condenseLimiter`.
- Per-route `express.json({ limit: "2.5mb" })` (the global 1 MB JSON parser in `src/app.ts` skips this prefix only — every other pitch route keeps its 1 MB cap).
- Body: `{ text: string, targetBytes?: number }` (`.strict()` Zod).
- Returns `{ condensed, originalBytes, condensedBytes, chunks }`.
- Errors: `413 { error: "script_too_large", maxBytes: 2_000_000 }` for over-ceiling input; `502 { error: "condense_failed", detail }` on LLM failure.
- Audit: `category: system, event: pitch.script.condensed` on success; `category: security, event: pitch.rate_limit_exceeded` on 429.

## Cost shape

Map-reduce: input is split into ~30 000-character chunks on paragraph boundaries; each chunk is summarised by the Copilot LLM. If the concatenation is still over the 40 KB target, a single reduce pass folds them.

For a **459 KB script**: `chunks = ceil(459_000 / 30_000) = 16` map calls + 1 reduce call ≈ **17 LLM calls**, each ~6–8k input tokens → ~1–2k output tokens. Each call has a 1-retry budget on empty/malformed responses.

## File map

| File | Purpose |
|---|---|
| `src/pitch/pitch-condense.ts` | Map-reduce summariser (chunking, retry, hard ceiling) |
| `src/pitch/pitch-condense.test.ts` | 13 unit tests |
| `src/api/pitch.ts` | New route + `condenseLimiter` + 413/502 handling |
| `src/app.ts` | `skipGlobalParser` allowlist for the 2.5 MB route |
| `src/api/pitch.integration.test.ts` | 5 new integration tests (200, 413, 502, 400, 429) |
| `ui/app/pitch/new/page.tsx` | Drop/paste handlers, condense panel, info chip |
| `ui/app/pitch/new/page.test.tsx` | 4 new UI tests covering the condense flow |
| `docs/USER_GUIDE.md`, `docs/ARCHITECTURE.md`, `CHANGELOG.md` | Living docs |

## Tests

- Backend unit: `src/pitch/pitch-condense.test.ts` — 13/13 pass.
- Backend integration: `src/api/pitch.integration.test.ts` — 5 new + 13 existing all pass.
- UI: `ui/app/pitch/new/page.test.tsx` — 4 new + 7 existing all pass (11/11).
- Full suite: `pnpm test` (6990/6990) and `cd ui && pnpm test` (643/643) both green.
- `pnpm lint`, `pnpm typecheck`, and `cd ui && npx next build` all green.

## Out of scope

- The persisted 50 KB `source_script` cap is unchanged (per spec).
- No streaming UI (per spec).
- No auto-condensation (per spec — cost transparency).
- No version bump (per spec).
