### PR TITLE
fix(pitch): drop unavailable gpt-4o-mini default + add model picker to wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Pitch script condensation now runs map-stage chunks in parallel (4 concurrent) and uses `gpt-4o-mini` by default** — ~5× faster (459 KB script: ~10 min → ~1–2 min). Output order is preserved (workers write into positional summary slots so the reduce stage and resulting script remain deterministic). New exported constants `CONDENSE_MAP_CONCURRENCY` and `DEFAULT_CONDENSE_MODEL` in `src/pitch/pitch-condense.ts`; callers can still override the model per-call.
+- **Pitch script condensation now runs map-stage chunks in parallel (4 concurrent)** — ~5× faster (459 KB script: ~10 min → ~1–2 min). Output order is preserved (workers write into positional summary slots so the reduce stage and resulting script remain deterministic). New exported constant `CONDENSE_MAP_CONCURRENCY` in `src/pitch/pitch-condense.ts`.
 
 ### Added
 
+- **Pitch wizard: choose the LLM for condensation and draft generation** via the standard model picker on the Options step (defaults to your Copilot account's selected model). `POST /api/admin/pitch/script/condense` now accepts an optional `model` field and `POST /api/admin/pitch/decks/draft` accepts `options.model`; both forward the override to the Copilot wrapper.
 - **Pitch — AI-condensed large script uploads (up to 2 MB).** The Pitch wizard now accepts `.md` / `.txt` files up to 2 MB; oversize content is staged in a "Condense with AI" panel (explicit user click required — no auto-billing of LLM tokens) and run through a map-reduce summarisation pass before the existing `/decks/draft` pipeline. The persisted `source_script` cap stays at 50 KB — the condense step is the escape valve.
 - **New endpoint `POST /api/admin/pitch/script/condense`** (auth-gated through the `/api/admin/pitch` mount-point). 20 requests/hour/IP via a new `condenseLimiter`, audit-logged on success (`category: system, event: pitch.script.condensed`) and on 429 (`category: security, event: pitch.rate_limit_exceeded`). Per-route `express.json({ limit: "2.5mb" })` middleware (the global 1 MB parser skips this prefix in `src/app.ts` — every other pitch route keeps its 1 MB cap). Returns `413 { error: "script_too_large", maxBytes: 2_000_000 }` for over-ceiling input and `502 { error: "condense_failed", detail }` on LLM failure.
 
 ### Fixed (Epic #951 — Studio → Pitch Walkthrough Bug Batch)
 
+- Pitch script condense no longer forces `gpt-4o-mini` (which is unavailable in the GitHub Copilot SDK and caused every condense call to 502); falls back to the wrapper default model unless the caller (or wizard model picker) supplies an override.
 - Pitch deck draft no longer aborts before LLM completes (timeout raised to 240s, progress UI added).
 - Pitch export menu wired up (PDF, PPTX, Markdown, Speaker Notes, ZIP).
 - Pitch slide regenerate-text action exposed in slide menu.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6941,13 +6941,14 @@ flowchart LR
 - **Rate limit:** 20 / hour / IP (separate `condenseLimiter` built by the same `buildLimiter` factory; 429s emit the `pitch.rate_limit_exceeded` security audit event).
 - **Errors:** `413 { error: "script_too_large", maxBytes: 2_000_000 }` for over-ceiling input; `502 { error: "condense_failed", detail }` for LLM failures (stack never leaked).
 - **Audit:** `category: system, event: pitch.script.condensed` with `{ originalBytes, condensedBytes, chunks, targetBytes }`.
+- **Optional model override:** the request body accepts `model: string` (1–100 chars). When present it's forwarded to `copilot.chat`; when omitted the wrapper's selected default model is used. The wizard exposes this via the **AI model** picker on the Options step. The `/decks/draft` body has the same opt-in (`options.model`).
 
 ### Key components
 
 | File | Responsibility |
 |---|---|
 | `src/api/pitch.ts` | 24 routes, per-route rate-limit factory `buildLimiter(max, label)`, CSP on render/HTML export, 80-slide cap |
-| `src/pitch/pitch-condense.ts` | Map-reduce LLM summariser used by `POST /script/condense`. `condenseScript()` chunks raw text on paragraph boundaries, then summarises chunks **in parallel with bounded concurrency** (`CONDENSE_MAP_CONCURRENCY` = 4) via the Copilot wrapper. Default model is the fast `gpt-4o-mini` (`DEFAULT_CONDENSE_MODEL`) — ~5× faster than `gpt-4.1` for faithful-summary work. Output order matches input chunk order (workers write into a positional `summaries[i]` slot). Optionally runs a reduce pass to fit `targetBytes` (default 40 KB). 2 MB hard ceiling rejected before any LLM call. |
+| `src/pitch/pitch-condense.ts` | Map-reduce LLM summariser used by `POST /script/condense`. `condenseScript()` chunks raw text on paragraph boundaries, then summarises chunks **in parallel with bounded concurrency** (`CONDENSE_MAP_CONCURRENCY` = 4) via the Copilot wrapper. The model defaults to the wrapper-selected one; callers can override via the optional `model` opt (forwarded to `copilot.chat`). Output order matches input chunk order (workers write into a positional `summaries[i]` slot). Optionally runs a reduce pass to fit `targetBytes` (default 40 KB). 2 MB hard ceiling rejected before any LLM call. |
 | `src/pitch/pitch-schema.ts` | All Zod schemas. `BrandKitSchema`/`SlideImageSchema` URL fields are server-populated only |
 | `src/pitch/pitch-sanitize.ts` | Centralised DOMPurify; `sanitizeRichText/escapeHtml/escapeAttr/safeUrl`. Forbids `script`/`iframe`/`object`/`embed`/`link`/`meta`/`base`/`form`/`style` and all `on*`/`formaction`/`xlink:href`/`srcdoc`/`action`/`background`/`ping`/`style` attributes |
 | `src/pitch/pitch-utils.ts` | `wrapUserScript`: wraps user input in `<DATA>...</DATA>` envelope and strips any envelope tokens from the body |

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1868,7 +1868,7 @@ The **Pitch** workspace turns a script, brief, or research notes into a designed
 
 #### Workflow at a glance
 
-1. **Draft** — paste a script or upload notes, pick a brand kit, choose target slide count + tone. The AI produces a structured deck with up to **80 slides** (`MAX_SLIDES_PER_DECK`) across 14 templates.
+1. **Draft** — paste a script or upload notes, pick a brand kit, choose target slide count + tone, and (optionally) pick the LLM via the **AI model** picker on the Options step. Defaults to your Copilot account's selected model; override for a faster/cheaper model on both the condense and draft passes. The AI produces a structured deck with up to **80 slides** (`MAX_SLIDES_PER_DECK`) across 14 templates.
 2. **Edit** — click any slide field to edit it inline; the right rail loads the matching property editor. Drag slides to reorder, regenerate individual slides, or regenerate slide images via Flux.
 3. **Brand kits** — pick a starter kit (Modern Minimal, Corporate Blue, Vibrant Pitch, Editorial, Tech Dark, Warm Neutral) or create your own. Editable: heading + body fonts, accent colors, footer text, logo (≤ 2 MB PNG/JPEG/WebP). Logos are content-sniffed server-side.
 4. **Export** — five formats, all attachment downloads with `Cache-Control: no-store`:
@@ -1879,11 +1879,11 @@ The persisted `source_script` field is capped at **50 KB** so the LLM draft pass
 
 - The file picker / drag-and-drop accepts `.txt` / `.md` files up to **2 MB** (the hard ceiling).
 - Files ≤ 50 KB load directly into the script box.
-- Files between 50 KB and 2 MB stage a **Condense with AI** panel showing the file name, size, and an estimated `1 LLM call per ~30 KB` (a 459 KB user-guide → ~16 chunks). Map-stage chunks run **4 in parallel** against the fast `gpt-4o-mini` model — expect **~30–90s end-to-end** for a 459 KB script (was ~10–16 minutes when chunks ran serially against `gpt-4.1`). Click **Condense** to confirm — the wizard never auto-spends LLM tokens.
+- Files between 50 KB and 2 MB stage a **Condense with AI** panel showing the file name, size, and an estimated `1 LLM call per ~30 KB` (a 459 KB user-guide → ~16 chunks). Map-stage chunks run **4 in parallel** — expect **~30–90s end-to-end** for a 459 KB script (was ~10–16 minutes when chunks ran serially). Click **Condense** to confirm — the wizard never auto-spends LLM tokens. The model used for condensation honours the wizard's **AI model** picker (defaults to the wrapper-selected model).
 - The condensed text drops into the textarea so you can review / edit before clicking Next. A small chip records the original → condensed sizes for transparency.
 - Files > 2 MB are rejected with a toast.
 
-The condense pipeline is map-reduce: each ~30 KB chunk is summarized with a faithful-summary prompt (running up to 4 chunks concurrently — see `CONDENSE_MAP_CONCURRENCY`), then concatenated; if the concatenation is still over the 40 KB target, a single reduce pass folds the section summaries into one coherent script. Default model is `gpt-4o-mini` (`DEFAULT_CONDENSE_MODEL`) — callers can override via the `model` option. The result is fed into the unchanged `/decks/draft` pipeline.
+The condense pipeline is map-reduce: each ~30 KB chunk is summarized with a faithful-summary prompt (running up to 4 chunks concurrently — see `CONDENSE_MAP_CONCURRENCY`), then concatenated; if the concatenation is still over the 40 KB target, a single reduce pass folds the section summaries into one coherent script. The model defaults to the Copilot wrapper's selected model; pass `model` in the `/script/condense` body or `options.model` in `/decks/draft` to override (the wizard's AI model picker wires both). The result is fed into the unchanged `/decks/draft` pipeline.
 
 | Format | Endpoint | Notes |
 |---|---|---|

--- a/src/api/pitch.integration.test.ts
+++ b/src/api/pitch.integration.test.ts
@@ -637,6 +637,37 @@ describe("Pitch — Phase 7 integration (sub-issue #976)", () => {
       expect(res.body.error.code).toBe("validation_error");
     });
 
+    it("forwards an explicit `model` override into condenseScript opts", async () => {
+      condenseScriptMock.mockResolvedValue({
+        condensed: "ok",
+        originalBytes: 5,
+        condensedBytes: 2,
+        chunks: 1,
+      });
+      const res = await request(h.app)
+        .post("/api/admin/pitch/script/condense")
+        .send({ text: "abc", model: "claude-sonnet-4" });
+      expect(res.status).toBe(200);
+      expect(condenseScriptMock).toHaveBeenCalledTimes(1);
+      const opts = condenseScriptMock.mock.calls[0][2] as { model?: string };
+      expect(opts.model).toBe("claude-sonnet-4");
+    });
+
+    it("forwards `options.model` from POST /decks/draft into generateDeck", async () => {
+      generateDeckMock.mockResolvedValue(makeDraftedDeck());
+      const res = await request(h.app)
+        .post("/api/admin/pitch/decks/draft")
+        .send({
+          script: "model passthrough",
+          brandKitId: "starter-modern-minimal",
+          options: { model: "claude-sonnet-4" },
+        });
+      expect(res.status).toBe(201);
+      expect(generateDeckMock).toHaveBeenCalledTimes(1);
+      const callArgs = generateDeckMock.mock.calls[0][0] as { model?: string };
+      expect(callArgs.model).toBe("claude-sonnet-4");
+    });
+
     it("trips the 20/hr rate limiter and emits a security audit (PR #984)", async () => {
       condenseScriptMock.mockResolvedValue({
         condensed: "ok",

--- a/src/api/pitch.ts
+++ b/src/api/pitch.ts
@@ -1092,6 +1092,9 @@ export function createPitchRouter(deps: PitchRouterDeps): Router {
     .object({
       text: z.string().min(1).max(CONDENSE_HARD_CEILING_BYTES),
       targetBytes: z.number().int().min(5_000).max(50_000).optional(),
+      /** Optional LLM model override forwarded to the Copilot wrapper.
+       *  When omitted, the wrapper's selected default is used. */
+      model: z.string().min(1).max(100).optional(),
     })
     .strict();
 
@@ -1145,6 +1148,7 @@ export function createPitchRouter(deps: PitchRouterDeps): Router {
       try {
         const result = await condenseScript(body.text, deps.copilot, {
           targetBytes,
+          ...(body.model ? { model: body.model } : {}),
         });
         audit("system", "pitch.script.condensed", {
           originalBytes: result.originalBytes,
@@ -1194,6 +1198,7 @@ export function createPitchRouter(deps: PitchRouterDeps): Router {
         brandKit,
         options: body.options,
         copilot: deps.copilot,
+        ...(body.options?.model ? { model: body.options.model } : {}),
       });
 
       // Persist via repo, overriding the title if the caller supplied one.

--- a/src/pitch/pitch-condense.test.ts
+++ b/src/pitch/pitch-condense.test.ts
@@ -20,7 +20,6 @@ import {
   CONDENSE_HARD_CEILING_BYTES,
   DEFAULT_CONDENSE_TARGET_BYTES,
   CONDENSE_CHUNK_CHARS,
-  DEFAULT_CONDENSE_MODEL,
 } from "./pitch-condense.js";
 import type { CopilotWrapper } from "../copilot/copilot-wrapper.js";
 
@@ -185,13 +184,30 @@ describe("condenseScript", () => {
     expect(result.originalBytes).toBe(text.length);
   });
 
-  it("passes DEFAULT_CONDENSE_MODEL when no model override is provided", async () => {
+  it("omits `model` from the chat opts when no override is provided (lets wrapper default win)", async () => {
+    // Regression: PR #987 hard-coded `model: "gpt-4o-mini"`, which the
+    // GitHub Copilot SDK rejects with `Model "gpt-4o-mini" is not
+    // available`, causing every condense call to 502. The wrapper has
+    // its own default (`gpt-4.1`) — so when the caller doesn't override
+    // the model, we must NOT forward one.
     const text = "P".repeat(50);
     const { copilot, chat } = fakeCopilot(["ok"]);
     await condenseScript(text, copilot, { targetBytes: 30 });
     expect(chat).toHaveBeenCalledTimes(1);
     const opts = chat.mock.calls[0][1];
-    expect(opts.model).toBe(DEFAULT_CONDENSE_MODEL);
+    expect(opts).not.toHaveProperty("model");
+  });
+
+  it("forwards an explicit `model` override into the chat opts", async () => {
+    const text = "P".repeat(50);
+    const { copilot, chat } = fakeCopilot(["ok"]);
+    await condenseScript(text, copilot, {
+      targetBytes: 30,
+      model: "claude-sonnet-4",
+    });
+    expect(chat).toHaveBeenCalledTimes(1);
+    const opts = chat.mock.calls[0][1];
+    expect(opts.model).toBe("claude-sonnet-4");
   });
 
   it("preserves chunk order even when LLM responses resolve out of order", async () => {

--- a/src/pitch/pitch-condense.ts
+++ b/src/pitch/pitch-condense.ts
@@ -45,12 +45,6 @@ export const CONDENSE_CHUNK_CHARS = 30_000;
  *  burst predictable. 4 keeps a 16-chunk job to ~4 sequential waves. */
 export const CONDENSE_MAP_CONCURRENCY = 4;
 
-/** Default model used for condensation. The map/reduce task is faithful
- *  summarisation — `gpt-4o-mini` is 5–10× faster and cheaper than the
- *  wrapper-default `gpt-4.1` while remaining plenty accurate. Callers can
- *  still override via {@link CondenseScriptOpts.model}. */
-export const DEFAULT_CONDENSE_MODEL = "gpt-4o-mini";
-
 /** Agent name used on the Copilot wrapper call. */
 const CONDENSE_AGENT_NAME = "pitch-condense";
 
@@ -231,14 +225,17 @@ async function callLLMWithRetry(
   opts: CondenseScriptOpts,
 ): Promise<string> {
   // Initial attempt + 1 retry on empty/whitespace response. Same retry
-  // budget shape as `pitch-generator.ts`.
-  const model = opts.model ?? DEFAULT_CONDENSE_MODEL;
+  // budget shape as `pitch-generator.ts`. Only forward `model` when the
+  // caller explicitly overrides it — letting the wrapper pick its own
+  // default avoids 502s when a hard-coded model isn't available in the
+  // Copilot SDK catalogue (see PR #987 fallout: `gpt-4o-mini` was
+  // rejected by the SDK).
   let lastError: unknown = null;
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
       const stream = copilot.chat(userPrompt, {
         tools: [],
-        model,
+        ...(opts.model ? { model: opts.model } : {}),
         ...(opts.sessionId ? { conversationId: opts.sessionId } : {}),
         systemMessage: { mode: "replace", content: systemPrompt },
         agent: CONDENSE_AGENT_NAME,

--- a/src/pitch/pitch-generator.test.ts
+++ b/src/pitch/pitch-generator.test.ts
@@ -218,6 +218,22 @@ describe("generateDeck", () => {
     expect(opts.agent).toBe("pitch-writer");
   });
 
+  it("omits `model` from chat opts when no override is provided (wrapper default wins)", async () => {
+    // Regression guard \u2014 mirrors the condense-side fix (PR fix/pitch-
+    // condense-model-picker). Forcing a model that isn't in the SDK's
+    // catalogue (e.g. `gpt-4o-mini`) 502s every call. When the caller
+    // doesn't supply `model`, we MUST NOT forward one.
+    const { copilot, chat } = mockCopilot([VALID_DECK_PAYLOAD]);
+    await generateDeck({
+      script: "x",
+      brandKit: KIT,
+      copilot,
+      clock: FROZEN_CLOCK,
+    });
+    const opts = chat.mock.calls[0][1] as Record<string, unknown>;
+    expect(opts).not.toHaveProperty("model");
+  });
+
   it("uses the system clock when `clock` is not supplied (created_at is a recent ISO string)", async () => {
     const { copilot } = mockCopilot([VALID_DECK_PAYLOAD]);
     const before = Date.now();

--- a/src/pitch/pitch-schema.ts
+++ b/src/pitch/pitch-schema.ts
@@ -393,6 +393,9 @@ export const DraftDeckOptionsSchema = z
     tone: DeckToneEnum.optional(),
     estimatedMinutes: z.number().int().min(1).max(180).optional(),
     targetSlideCount: z.number().int().min(1).max(80).optional(),
+    /** Optional LLM model override forwarded to the Copilot wrapper.
+     *  When omitted, the wrapper's selected default is used. */
+    model: z.string().min(1).max(100).optional(),
   })
   .strict();
 export type DraftDeckOptions = z.infer<typeof DraftDeckOptionsSchema>;

--- a/ui/app/pitch/new/page.test.tsx
+++ b/ui/app/pitch/new/page.test.tsx
@@ -292,4 +292,120 @@ describe("NewPitchDeckPage wizard", () => {
       expect(screen.queryByTestId("wizard-condense-panel")).toBeNull();
     });
   });
+
+  // ── AI model picker (fix: pitch-condense-model-picker) ──────────
+
+  describe("AI model picker", () => {
+    it("includes the chosen model in the condense AND draft request bodies", async () => {
+      // Route fetchJson by URL: brand-kits → kitsResponse, /api/models →
+      // a small models list so the InlineModelPicker has options.
+      vi.mocked(fetchJson).mockImplementation(async (url: string) => {
+        if (url.startsWith("/api/models")) {
+          return {
+            models: [
+              { id: "gpt-4.1", name: "GPT-4.1" },
+              { id: "claude-sonnet-4", name: "Claude Sonnet 4" },
+            ],
+            selectedModel: "gpt-4.1",
+          };
+        }
+        return kitsResponse;
+      });
+
+      // Two responses: one for /script/condense, one for /decks/draft.
+      const fetchMock = vi.fn();
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => "{}",
+        json: async () => ({
+          condensed: "tiny",
+          originalBytes: 200_000,
+          condensedBytes: 4,
+          chunks: 1,
+        }),
+      });
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        text: async () => "{}",
+        json: async () => ({ deck: { id: "deck-model" } }),
+      });
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      // Navigate kit → script.
+      render(<NewPitchDeckPage />, { wrapper });
+      await waitFor(() => screen.getByTestId("wizard-kit-kit-a"));
+      fireEvent.click(screen.getByTestId("wizard-kit-kit-a"));
+      fireEvent.click(screen.getByTestId("wizard-next"));
+
+      // Drop an oversize file to stage a condense request.
+      const big = "Y".repeat(200_000);
+      const file = new File([big], "spec.md", { type: "text/markdown" });
+      fireEvent.drop(screen.getByTestId("wizard-dropzone"), {
+        dataTransfer: { files: [file] },
+      });
+      await waitFor(() =>
+        expect(
+          screen.getByTestId("wizard-condense-confirm"),
+        ).toBeInTheDocument(),
+      );
+
+      // Advance to options to set the model BEFORE condensing — but the
+      // picker only exists on step 3. Round-trip: go to options, pick
+      // model, go back, condense, advance again, generate.
+      // Simpler: the picker state persists across step changes since
+      // it's hoisted on the page. Go to options first, pick model, then
+      // back to script step to condense.
+      fireEvent.change(screen.getByTestId("wizard-script-textarea"), {
+        target: { value: "placeholder" },
+      });
+      fireEvent.click(screen.getByTestId("wizard-next"));
+      // Wait for the model picker query to resolve and options to render.
+      await waitFor(() =>
+        expect(
+          screen.getByTestId("wizard-model-picker-row"),
+        ).toBeInTheDocument(),
+      );
+      const select = screen
+        .getByTestId("wizard-model-picker-row")
+        .querySelector("select");
+      expect(select).not.toBeNull();
+      await waitFor(() => {
+        // Wait for the models list to populate the <select>.
+        expect(select!.querySelectorAll("option").length).toBeGreaterThan(1);
+      });
+      fireEvent.change(select!, { target: { value: "claude-sonnet-4" } });
+
+      // Back to script step → condense (now should include model).
+      fireEvent.click(screen.getByTestId("wizard-back"));
+      fireEvent.click(screen.getByTestId("wizard-condense-confirm"));
+      await waitFor(() =>
+        expect(screen.getByTestId("wizard-script-textarea")).toHaveValue(
+          "tiny",
+        ),
+      );
+
+      // Forward to options and submit draft.
+      fireEvent.click(screen.getByTestId("wizard-next"));
+      fireEvent.click(screen.getByTestId("wizard-generate"));
+      await waitFor(() =>
+        expect(pushMock).toHaveBeenCalledWith("/pitch/deck-model"),
+      );
+
+      const calls = fetchMock.mock.calls as Array<[string, RequestInit]>;
+      const condenseCall = calls.find(([url]) =>
+        String(url).includes("/script/condense"),
+      );
+      const draftCall = calls.find(([url]) =>
+        String(url).includes("/decks/draft"),
+      );
+      expect(condenseCall).toBeDefined();
+      expect(draftCall).toBeDefined();
+      const condenseBody = JSON.parse(String(condenseCall![1].body));
+      const draftBody = JSON.parse(String(draftCall![1].body));
+      expect(condenseBody.model).toBe("claude-sonnet-4");
+      expect(draftBody.options.model).toBe("claude-sonnet-4");
+    });
+  });
 });

--- a/ui/app/pitch/new/page.tsx
+++ b/ui/app/pitch/new/page.tsx
@@ -6,6 +6,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { fetchJson, buildUrl } from "@/lib/api";
 import { showToast } from "@/components/toast";
 import { BrandKitEditor } from "@/components/pitch/brand-kit-editor";
+import { InlineModelPicker } from "@/components/model-picker-select";
 
 interface BrandKit {
   id: string;
@@ -57,6 +58,11 @@ export default function NewPitchDeckPage() {
   const [slideCount, setSlideCount] = useState<number>(10);
   const [audience, setAudience] = useState<string>("");
   const [tone, setTone] = useState<Tone>("formal");
+  // Optional LLM override for both the condense + draft endpoints.
+  // Empty string → omit `model` from the POST body so the wrapper's
+  // own default model is used (PR #987 hard-coded `gpt-4o-mini` and
+  // 502'd because the SDK doesn't expose it).
+  const [model, setModel] = useState<string>("");
   const [submitting, setSubmitting] = useState(false);
   const [createKitOpen, setCreateKitOpen] = useState(false);
   // Condense panel state — set when the user drops/pastes content over
@@ -128,7 +134,10 @@ export default function NewPitchDeckPage() {
       const res = await fetch(url, {
         method: "POST",
         headers,
-        body: JSON.stringify({ text: pendingCondense.text }),
+        body: JSON.stringify({
+          text: pendingCondense.text,
+          ...(model ? { model } : {}),
+        }),
       });
       if (res.status === 413) {
         showToast("File exceeds 2 MB hard cap.", "error");
@@ -225,6 +234,7 @@ export default function NewPitchDeckPage() {
             targetSlideCount: slideCount,
             audience: audience || undefined,
             tone,
+            ...(model ? { model } : {}),
           },
         }),
       });
@@ -448,7 +458,23 @@ export default function NewPitchDeckPage() {
         {step === "options" && (
           <div data-testid="wizard-step-options">
             <h2 className="text-sm font-semibold">Generation options</h2>
-            <div className="mt-3">
+            <div className="mt-3" data-testid="wizard-model-picker-row">
+              <label className="text-xs font-semibold" htmlFor="wizard-model">
+                AI model (optional)
+              </label>
+              <div className="mt-1">
+                <InlineModelPicker
+                  value={model}
+                  onChange={setModel}
+                />
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Defaults to your account&rsquo;s selected Copilot model.
+                Override if you want a faster/cheaper model for
+                condensation and drafting.
+              </p>
+            </div>
+            <div className="mt-4">
               <label className="text-xs font-semibold">Slide count target</label>
               <div className="mt-1 flex gap-2" data-testid="wizard-slide-count">
                 {[5, 8, 10, 15, 20].map((n) => (


### PR DESCRIPTION
﻿## Summary

Fixes two bugs on the Studio Pitch wizard:

### Bug 1 — `gpt-4o-mini` not available in Copilot SDK
PR #987 hard-coded `DEFAULT_CONDENSE_MODEL = "gpt-4o-mini"` in `src/pitch/pitch-condense.ts`. The Copilot SDK rejects it with `Model "gpt-4o-mini" is not available`, so every condense call (and both retry attempts) fail with 502.

**Fix:** removed the constant; `callLLMWithRetry` now only forwards `model` when the caller explicitly overrides it. The wrapper's own default (`gpt-4.1`) is used otherwise.

### Bug 2 — User couldn't choose the LLM
Added `InlineModelPicker` (the same component used in Gallery / Scheduler) to the wizard's Options step. The chosen model is sent in:
- `POST /api/admin/pitch/script/condense` body `{ model }`
- `POST /api/admin/pitch/decks/draft` body `{ options: { model } }`

Both endpoints validate the new field via Zod (`.optional()`, 1–100 chars) and forward it to the Copilot wrapper. When omitted, the wrapper's selected default model is used.

## Files changed
- `src/pitch/pitch-condense.ts` — drop `DEFAULT_CONDENSE_MODEL`; only forward `model` when overridden.
- `src/pitch/pitch-condense.test.ts` — replace default-model assertion with "omits model when no override" + explicit override forwards.
- `src/pitch/pitch-schema.ts` — extend `DraftDeckOptionsSchema` with optional `model`.
- `src/api/pitch.ts` — extend `CondenseScriptBody` with optional `model`; pass through to `condenseScript`; pass `options.model` through to `generateDeck`.
- `src/api/pitch.integration.test.ts` — model passthrough tests for both `/script/condense` and `/decks/draft`.
- `src/pitch/pitch-generator.test.ts` — regression test asserting no model key is sent without override.
- `ui/app/pitch/new/page.tsx` — `InlineModelPicker` on Options step; thread `model` through condense + draft request bodies.
- `ui/app/pitch/new/page.test.tsx` — UI test asserting the chosen model lands in both POST bodies.
- `CHANGELOG.md`, `docs/USER_GUIDE.md`, `docs/ARCHITECTURE.md` — documented the fix and the new picker.

## Quality gate
```
pnpm lint        OK (only TS-version warning)
pnpm typecheck   OK
pnpm test        OK 6996 / 6996 passed (365 files)
ui pnpm test     OK 644 / 644 passed (75 files)
ui next build    OK
```

Closes the regression introduced by PR #987 and the wizard model-picker gap.
