### PR TITLE
fix(pitch): partial image normalization + SDK session reuse + model picker placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Pitch condense reuses one Copilot SDK session per parallel worker slot** (4 sessions for a 16-chunk document) instead of creating and destroying a fresh session per chunk. Eliminates the 16× "session started / session ended" churn observed in logs. Sessions are destroyed in a `finally` block guaranteeing cleanup on success and failure paths alike.
+- **Pitch wizard model picker moved to the Script step** (inside the "Condense with AI" panel) in addition to the Options step, so the model choice is visible at the point of use.
 - **Pitch script condensation now runs map-stage chunks in parallel (4 concurrent)** — ~5× faster (459 KB script: ~10 min → ~1–2 min). Output order is preserved (workers write into positional summary slots so the reduce stage and resulting script remain deterministic). New exported constant `CONDENSE_MAP_CONCURRENCY` in `src/pitch/pitch-condense.ts`.
+
+### Fixed
+
+- **Pitch deck draft no longer 500s on partial `image` blocks emitted by the LLM** (e.g. `"image": {}` or `"image": { "url": null }`). New `normalizeImageBlocks()` pass in `src/pitch/pitch-utils.ts` walks every slide's `content`, finds objects that "look like an image" (have any of `prompt` / `url` / `alt`), and backfills missing required fields with safe defaults derived from the surrounding slide heading. Applied to both full-deck draft (`assembleDeck`) and per-slide regeneration.
 
 ### Added
 

--- a/src/pitch/pitch-condense.test.ts
+++ b/src/pitch/pitch-condense.test.ts
@@ -46,8 +46,10 @@ function fakeCopilot(outputs: string[]): {
     i += 1;
     return streamOf(out);
   });
+  const hasSession = vi.fn().mockReturnValue(false);
+  const destroySession = vi.fn().mockResolvedValue(undefined);
   return {
-    copilot: { chat } as unknown as CopilotWrapper,
+    copilot: { chat, hasSession, destroySession } as unknown as CopilotWrapper,
     chat,
   };
 }
@@ -237,7 +239,11 @@ describe("condenseScript", () => {
         yield label;
       })();
     });
-    const copilot = { chat } as unknown as CopilotWrapper;
+    const copilot = {
+      chat,
+      hasSession: vi.fn().mockReturnValue(false),
+      destroySession: vi.fn().mockResolvedValue(undefined),
+    } as unknown as CopilotWrapper;
 
     const result = await condenseScript(text, copilot, { targetBytes: 50_000 });
 

--- a/src/pitch/pitch-condense.ts
+++ b/src/pitch/pitch-condense.ts
@@ -23,6 +23,7 @@
  * with `vi.fn()` returning canned summaries without dragging in the deck
  * generator's prompt builders.
  */
+import { randomUUID } from "node:crypto";
 import type { CopilotWrapper } from "../copilot/copilot-wrapper.js";
 import { logger } from "../logging/logger.js";
 import { accumulateStream } from "./pitch-utils.js";
@@ -121,9 +122,23 @@ export async function condenseScript(
 
   // Preserve input order — workers write into `summaries[i]` by index.
   // The reduce step below relies on positional ordering.
+  const poolSize = Math.min(CONDENSE_MAP_CONCURRENCY, chunks.length);
+
+  // Allocate one SDK session per worker slot so the Copilot SDK session
+  // is created ONCE per worker and reused across all sequential chunks
+  // it processes — avoids 16 session-create/destroy cycles for a 16-chunk
+  // document (would be 4 instead).  Sessions are always destroyed in the
+  // finally block regardless of success or failure.
+  const baseId = opts.sessionId ?? randomUUID();
+  const workerSessionIds = Array.from(
+    { length: poolSize },
+    (_, i) => `${baseId}-w${i}`,
+  );
+
   const summaries: Array<string | undefined> = new Array(chunks.length);
   let nextIndex = 0;
-  const worker = async (): Promise<void> => {
+  const worker = async (workerIdx: number): Promise<void> => {
+    const conversationId = workerSessionIds[workerIdx];
     for (;;) {
       const i = nextIndex++;
       if (i >= chunks.length) return;
@@ -133,13 +148,23 @@ export async function condenseScript(
         userPrompt,
         MAP_SYSTEM_PROMPT,
         opts,
+        conversationId,
       );
     }
   };
-  const poolSize = Math.min(CONDENSE_MAP_CONCURRENCY, chunks.length);
+
   // If any worker rejects, Promise.all surfaces the first failure and
   // we propagate it — current behaviour is "fail the whole call".
-  await Promise.all(Array.from({ length: poolSize }, () => worker()));
+  try {
+    await Promise.all(Array.from({ length: poolSize }, (_, i) => worker(i)));
+  } finally {
+    // Clean up worker sessions regardless of success or failure.
+    for (const sid of workerSessionIds) {
+      if (copilot.hasSession(sid)) {
+        copilot.destroySession(sid).catch(() => { /* best-effort */ });
+      }
+    }
+  }
 
   let condensed = (summaries as string[]).join("\n\n");
   let condensedBytes = Buffer.byteLength(condensed, "utf8");
@@ -156,12 +181,20 @@ export async function condenseScript(
       "",
       condensed,
     ].join("\n");
-    condensed = await callLLMWithRetry(
-      copilot,
-      reduceUserPrompt,
-      reduceSystemPrompt,
-      opts,
-    );
+    const reduceSessionId = `${baseId}-reduce`;
+    try {
+      condensed = await callLLMWithRetry(
+        copilot,
+        reduceUserPrompt,
+        reduceSystemPrompt,
+        opts,
+        reduceSessionId,
+      );
+    } finally {
+      if (copilot.hasSession(reduceSessionId)) {
+        copilot.destroySession(reduceSessionId).catch(() => { /* best-effort */ });
+      }
+    }
     condensedBytes = Buffer.byteLength(condensed, "utf8");
   }
 
@@ -223,6 +256,7 @@ async function callLLMWithRetry(
   userPrompt: string,
   systemPrompt: string,
   opts: CondenseScriptOpts,
+  conversationId: string,
 ): Promise<string> {
   // Initial attempt + 1 retry on empty/whitespace response. Same retry
   // budget shape as `pitch-generator.ts`. Only forward `model` when the
@@ -230,13 +264,16 @@ async function callLLMWithRetry(
   // default avoids 502s when a hard-coded model isn't available in the
   // Copilot SDK catalogue (see PR #987 fallout: `gpt-4o-mini` was
   // rejected by the SDK).
+  // `conversationId` is always provided by the caller so the SDK session
+  // is reused across retries and sequential chunks (see session-per-worker
+  // allocation in `condenseScript`).
   let lastError: unknown = null;
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
       const stream = copilot.chat(userPrompt, {
         tools: [],
         ...(opts.model ? { model: opts.model } : {}),
-        ...(opts.sessionId ? { conversationId: opts.sessionId } : {}),
+        conversationId,
         systemMessage: { mode: "replace", content: systemPrompt },
         agent: CONDENSE_AGENT_NAME,
       } as Parameters<CopilotWrapper["chat"]>[1]);

--- a/src/pitch/pitch-generator.ts
+++ b/src/pitch/pitch-generator.ts
@@ -35,7 +35,8 @@ import {
   MAX_USER_SCRIPT_BYTES,
   accumulateStream,
   buildRetryHint,
-  parseAndValidate,
+  normalizeImageBlocks,
+  stripCodeFences,
   wrapUserScript,
 } from "./pitch-utils.js";
 
@@ -191,14 +192,14 @@ export async function regenerateSlide(opts: RegenerateSlideOpts): Promise<Slide>
   let lastError: unknown = null;
   let raw = await callOnceForSlide(opts, userPrompt, systemPrompt);
   try {
-    return parseAndValidate(raw, SlideSchema);
+    return parseRawDeck(raw, SlideSchema);
   } catch (err) {
     lastError = err;
   }
 
   const retryPrompt = [userPrompt, "", buildRetryHint(lastError)].join("\n");
   raw = await callOnceForSlide(opts, retryPrompt, systemPrompt);
-  return parseAndValidate(raw, SlideSchema);
+  return parseRawDeck(raw, SlideSchema);
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -251,7 +252,7 @@ function assembleDeck(raw: string, opts: GenerateDeckOpts): Deck {
   // bound) so we can truncate down to MAX_SLIDES_PER_DECK as a defence-in-
   // depth step rather than throwing the whole draft away. The final
   // `DeckSchema.parse()` below re-applies the strict `max(80)` limit.
-  const parsed = parseAndValidate(raw, DeckSchema.partial({
+  const parsed = parseRawDeck(raw, DeckSchema.partial({
     id: true,
     brand_kit_id: true,
     created_at: true,
@@ -297,4 +298,29 @@ function assembleDeck(raw: string, opts: GenerateDeckOpts): Deck {
 
   // Final validation — guarantees we hand back a fully-typed Deck.
   return DeckSchema.parse(deck);
+}
+
+/**
+ * Parse the raw LLM payload, repair partial `image` blocks the model often
+ * emits with missing `prompt`/`alt`, then validate against `schema`. Mirrors
+ * `parseAndValidate` but inserts a normalization pass between JSON.parse and
+ * Zod validation so a `"image": {}` from the model doesn't 500 the request.
+ */
+function parseRawDeck<S extends z.ZodTypeAny>(
+  raw: string,
+  schema: S,
+): z.infer<S> {
+  const cleaned = stripCodeFences(raw);
+  if (!cleaned) {
+    throw new Error("pitch: model returned empty output");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(cleaned);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`pitch: model output is not valid JSON: ${msg}`);
+  }
+  normalizeImageBlocks(parsed);
+  return schema.parse(parsed) as z.infer<S>;
 }

--- a/src/pitch/pitch-utils.ts
+++ b/src/pitch/pitch-utils.ts
@@ -72,6 +72,79 @@ export async function accumulateStream(
 }
 
 /**
+ * Repair LLM-emitted slide payloads that include a partial `image`-shaped
+ * object (any of `prompt` / `url` / `alt`) but are missing the required
+ * fields. Walks every slide's `content` recursively and, for any nested
+ * object that "looks like an image", fills the missing fields with safe
+ * defaults derived from the surrounding slide so Zod validation passes.
+ *
+ * Models routinely emit `"image": {}` or `"image": { "url": null }` for
+ * optional image slots; this stops the whole deck from failing validation
+ * over a missing prompt/alt the user never asked for.
+ */
+export function normalizeImageBlocks(payload: unknown): void {
+  if (!payload || typeof payload !== "object") return;
+  const root = payload as { slides?: unknown };
+  if (Array.isArray(root.slides)) {
+    for (const slide of root.slides) normalizeSlide(slide);
+    return;
+  }
+  // Single slide payload (regenerate-slide path).
+  normalizeSlide(payload);
+}
+
+function normalizeSlide(slide: unknown): void {
+  if (!slide || typeof slide !== "object") return;
+  const s = slide as Record<string, unknown>;
+  const content = s.content;
+  if (!content || typeof content !== "object") return;
+  const headingHint =
+    pickString(content, ["heading", "title", "caption", "overlay_text"]) ??
+    pickString(s, ["template"]) ??
+    "slide";
+  repairImageFields(content as Record<string, unknown>, headingHint);
+}
+
+function pickString(
+  obj: Record<string, unknown> | unknown,
+  keys: string[],
+): string | undefined {
+  if (!obj || typeof obj !== "object") return undefined;
+  const o = obj as Record<string, unknown>;
+  for (const k of keys) {
+    const v = o[k];
+    if (typeof v === "string" && v.trim()) return v.trim();
+  }
+  return undefined;
+}
+
+function looksLikeImage(v: unknown): v is Record<string, unknown> {
+  if (!v || typeof v !== "object" || Array.isArray(v)) return false;
+  const o = v as Record<string, unknown>;
+  return "prompt" in o || "url" in o || "alt" in o;
+}
+
+function repairImageFields(
+  container: Record<string, unknown>,
+  headingHint: string,
+): void {
+  for (const [key, value] of Object.entries(container)) {
+    if (!looksLikeImage(value)) continue;
+    const img = value as Record<string, unknown>;
+    const fallback = `${headingHint} — ${key.replace(/_/g, " ")}`.slice(0, 200);
+    if (typeof img.prompt !== "string" || img.prompt.trim().length < 3) {
+      img.prompt = fallback;
+    }
+    if (typeof img.alt !== "string") {
+      img.alt = fallback;
+    }
+    if (!("url" in img) || (typeof img.url !== "string" && img.url !== null)) {
+      img.url = null;
+    }
+  }
+}
+
+/**
  * Try to JSON.parse the (possibly fenced) `raw` payload and validate it
  * against `schema`. Throws a descriptive Error on failure — callers handle
  * the retry policy themselves.

--- a/ui/app/pitch/new/page.tsx
+++ b/ui/app/pitch/new/page.tsx
@@ -390,6 +390,14 @@ export default function NewPitchDeckPage() {
                 <div className="mt-1 text-muted-foreground">
                   Condense with AI (~5–15s per chunk, 4 in parallel).
                 </div>
+                <div className="mt-2">
+                  <label className="text-xs font-semibold text-foreground">
+                    AI model
+                  </label>
+                  <div className="mt-1">
+                    <InlineModelPicker value={model} onChange={setModel} />
+                  </div>
+                </div>
                 <div className="mt-2 flex gap-2">
                   <button
                     type="button"
@@ -463,15 +471,11 @@ export default function NewPitchDeckPage() {
                 AI model (optional)
               </label>
               <div className="mt-1">
-                <InlineModelPicker
-                  value={model}
-                  onChange={setModel}
-                />
+                <InlineModelPicker value={model} onChange={setModel} />
               </div>
               <p className="mt-1 text-xs text-muted-foreground">
-                Defaults to your account&rsquo;s selected Copilot model.
-                Override if you want a faster/cheaper model for
-                condensation and drafting.
+                Defaults to your account&rsquo;s selected Copilot model. Also
+                applies to condensation if you go back and re-condense.
               </p>
             </div>
             <div className="mt-4">


### PR DESCRIPTION
## Summary

Three small but high-signal fixes to the Pitch wizard:

1. **Generate fails with Zod errors on partial image blocks** — the LLM frequently emits `"image": {}` or `"image": { "url": null }` for optional image slots in `bullet_list` / `two_column` / `image_caption` slides, and the entire deck draft fails Zod validation with `Required` errors on `image.prompt` / `image.alt`. Added `normalizeImageBlocks()` in `src/pitch/pitch-utils.ts` that walks every slide's content and backfills missing required image fields with safe defaults derived from the surrounding heading. Wired into both full-deck draft (`assembleDeck`) and per-slide regen (`regenerateSlide`) via a new `parseRawDeck()` helper.
2. **Condense churns 16 SDK sessions** — `copilot.chat()` without a `conversationId` creates an ephemeral session per call. Workers now allocate one session per pool slot (4 sessions for a 16-chunk script) and destroy them in `finally`. `callLLMWithRetry` now takes a required `conversationId: string`.
3. **Model picker only visible on Options step** — added the `InlineModelPicker` to the condense panel on the Script step too, so the choice is visible at the point of use.

## Tests

- 16/16 condense tests pass (`pitch-condense.test.ts`)
- 356/356 pitch tests pass (`src/pitch`)
- TypeScript clean, UI build clean

## Closes

Companion to Epic #951 walkthrough fixes.
