### PR TITLE
feat(pitch): regenerate title-slide background end-to-end (closes #992)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,6 @@ ui/cov-*.txt
 ui/cov-*.cjs
 ui/coverage-output.txt
 ui/vitest-out.*
+
+# Transient PR body drafts written by gh CLI flows
+pr_body*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Pitch deck rendering now displays per-slide background images** regenerated via the title-slide property editor. The Reveal `<section>` for each slide now emits a `data-background-image` attribute (plus `data-background-size="cover"` and `data-background-position="center"`) when a `kind="background"` asset exists for that slide; the latest asset by `created_at` wins. Backwards-compatible — when no background asset is present the renderer behaves exactly as before. (#992)
+- **New endpoint `GET /api/admin/pitch/decks/:deckId/assets/:assetId`** serves slide asset bytes (typically flux-generated backgrounds) directly from disk. Hardened against path traversal (resolved `local_path` must lie under `assetsBaseDir`), cross-deck leakage (asset must belong to the URL's deck), and stale caches (`Cache-Control: no-store`). Rate-limited via the existing `crudLimiter` and auth-gated through the `/api/admin/pitch` mount point. (#992)
+- **Regenerate-image dialog "Replace?" preview.** When the dialog is opened with a `currentImageUrl` prop it now renders a small thumbnail of the existing image with a "Replace?" caption above the prompt, so the user can confirm what they're about to overwrite. Client-side URL allowlist mirrors the server-side `safeUrl` check. (#992)
+
 ### Changed
 
 - **Pitch condense reuses one Copilot SDK session per parallel worker slot** (4 sessions for a 16-chunk document) instead of creating and destroying a fresh session per chunk. Eliminates the 16× "session started / session ended" churn observed in logs. Sessions are destroyed in a `finally` block guaranteeing cleanup on success and failure paths alike.

--- a/src/api/pitch.test.ts
+++ b/src/api/pitch.test.ts
@@ -13,9 +13,9 @@ import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from "vite
 import express, { type Express } from "express";
 import request from "supertest";
 import Database from "better-sqlite3";
-import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, writeFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import sharp from "sharp";
 
 import { createPitchRouter, type PitchRouterDeps } from "./pitch.js";
@@ -1609,6 +1609,318 @@ describe("Pitch REST router", () => {
       );
       expect(notesRes.status).toBe(503);
       expect(notesRes.body.error.code).toBe("pdf_export_unavailable");
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Sub-issue #992 — asset-serve endpoint
+  // ─────────────────────────────────────────────────────────────────
+  describe("asset-serve endpoint (#992)", () => {
+    let assetsBaseDir: string;
+    let app: Express;
+    let deckId: string;
+    let slideId: string;
+
+    beforeEach(() => {
+      assetsBaseDir = mkdtempSync(join(tmpdir(), "pitch-assets-"));
+      const newDeps: PitchRouterDeps = { ...harness.deps, assetsBaseDir };
+      app = express();
+      app.use(express.json());
+      app.use("/api/admin/pitch", createPitchRouter(newDeps));
+      const kitId = createCustomKit(harness, "asset bg kit");
+      const ids = createDeck(harness, kitId, "Asset Deck");
+      deckId = ids.deckId;
+      slideId = ids.slideId;
+    });
+
+    afterEach(() => {
+      try {
+        rmSync(assetsBaseDir, { recursive: true, force: true });
+      } catch {
+        /* best effort */
+      }
+    });
+
+    function writeAsset(opts: {
+      assetId: string;
+      slideId: string | null;
+      kind: "background" | "image";
+      created_at?: string;
+      bytes?: Buffer;
+      relativePath?: string;
+    }): string {
+      const bytes = opts.bytes ?? Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+      const rel =
+        opts.relativePath ?? `${deckId}/${opts.assetId}.png`;
+      const abs = join(assetsBaseDir, rel);
+      mkdirSync(dirname(abs), { recursive: true });
+      writeFileSync(abs, bytes);
+      harness.deps.pitchRepo.insertAsset({
+        id: opts.assetId,
+        deck_id: deckId,
+        slide_id: opts.slideId,
+        kind: opts.kind,
+        source: "fluxq",
+        prompt: "test",
+        local_path: abs,
+        mime: "image/png",
+        width: 16,
+        height: 16,
+        created_at: opts.created_at ?? "2026-04-25T00:00:00Z",
+      });
+      return abs;
+    }
+
+    it("serves the asset bytes with Content-Type and no-store cache", async () => {
+      const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+      writeAsset({
+        assetId: "asset-good",
+        slideId,
+        kind: "background",
+        bytes,
+      });
+
+      const res = await request(app).get(
+        `/api/admin/pitch/decks/${deckId}/assets/asset-good`,
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toMatch(/image\/png/);
+      expect(res.headers["cache-control"]).toBe("no-store");
+      expect(Buffer.from(res.body).equals(bytes)).toBe(true);
+    });
+
+    it("returns 404 when the asset id does not exist", async () => {
+      const res = await request(app).get(
+        `/api/admin/pitch/decks/${deckId}/assets/does-not-exist`,
+      );
+      expect(res.status).toBe(404);
+      expect(res.body.error.code).toBe("not_found");
+    });
+
+    it("returns 404 when the asset belongs to a different deck", async () => {
+      const otherKit = createCustomKit(harness, "other kit");
+      const otherIds = createDeck(harness, otherKit, "Other Deck");
+      writeAsset({
+        assetId: "asset-other",
+        slideId: otherIds.slideId,
+        kind: "background",
+      });
+      // The repo row was created with deck_id=this.deckId (writeAsset hard-codes it),
+      // so to actually exercise the cross-deck guard we directly insert into the
+      // OTHER deck and try to fetch it via THIS deck's URL.
+      const otherAbs = join(assetsBaseDir, `${otherIds.deckId}-cross.png`);
+      writeFileSync(otherAbs, Buffer.from([1, 2, 3]));
+      harness.deps.pitchRepo.insertAsset({
+        id: "asset-cross-deck",
+        deck_id: otherIds.deckId,
+        slide_id: otherIds.slideId,
+        kind: "background",
+        source: "fluxq",
+        prompt: null,
+        local_path: otherAbs,
+        mime: "image/png",
+        width: 16,
+        height: 16,
+        created_at: "2026-04-25T00:00:00Z",
+      });
+      const res = await request(app).get(
+        `/api/admin/pitch/decks/${deckId}/assets/asset-cross-deck`,
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 404 when the asset's local_path escapes assetsBaseDir", async () => {
+      const escape = mkdtempSync(join(tmpdir(), "pitch-escape-"));
+      const escAbs = join(escape, "evil.png");
+      writeFileSync(escAbs, Buffer.from([9, 9, 9]));
+      harness.deps.pitchRepo.insertAsset({
+        id: "asset-escape",
+        deck_id: deckId,
+        slide_id: slideId,
+        kind: "background",
+        source: "fluxq",
+        prompt: null,
+        local_path: escAbs,
+        mime: "image/png",
+        width: 16,
+        height: 16,
+        created_at: "2026-04-25T00:00:00Z",
+      });
+      const res = await request(app).get(
+        `/api/admin/pitch/decks/${deckId}/assets/asset-escape`,
+      );
+      expect(res.status).toBe(404);
+      try {
+        rmSync(escape, { recursive: true, force: true });
+      } catch {
+        /* best effort */
+      }
+    });
+
+    it("returns 404 when the file on disk is missing even though the row exists", async () => {
+      const phantom = join(assetsBaseDir, `${deckId}/asset-phantom.png`);
+      // intentionally do NOT write the file
+      harness.deps.pitchRepo.insertAsset({
+        id: "asset-phantom",
+        deck_id: deckId,
+        slide_id: slideId,
+        kind: "background",
+        source: "fluxq",
+        prompt: null,
+        local_path: phantom,
+        mime: "image/png",
+        width: 16,
+        height: 16,
+        created_at: "2026-04-25T00:00:00Z",
+      });
+      const res = await request(app).get(
+        `/api/admin/pitch/decks/${deckId}/assets/asset-phantom`,
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("the /render endpoint emits data-background-image referencing the asset URL", async () => {
+      writeAsset({
+        assetId: "asset-bg-render",
+        slideId,
+        kind: "background",
+      });
+      const res = await request(app).get(
+        `/api/admin/pitch/decks/${deckId}/render`,
+      );
+      expect(res.status).toBe(200);
+      expect(res.text).toContain(
+        `data-background-image="/api/admin/pitch/decks/${deckId}/assets/asset-bg-render"`,
+      );
+    });
+
+    it("the /render endpoint picks the most-recent background per slide", async () => {
+      writeAsset({
+        assetId: "asset-old",
+        slideId,
+        kind: "background",
+        created_at: "2026-04-01T00:00:00Z",
+      });
+      writeAsset({
+        assetId: "asset-new",
+        slideId,
+        kind: "background",
+        created_at: "2026-04-25T00:00:00Z",
+      });
+      const res = await request(app).get(
+        `/api/admin/pitch/decks/${deckId}/render`,
+      );
+      expect(res.status).toBe(200);
+      expect(res.text).toContain("asset-new");
+      expect(res.text).not.toContain("asset-old");
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Sub-issue #992 — buildBackgroundImageUrlMap pure-function tests
+  // ─────────────────────────────────────────────────────────────────
+  describe("buildBackgroundImageUrlMap (#992)", () => {
+    it("returns an empty map when there are no assets", async () => {
+      const { buildBackgroundImageUrlMap } = await import("./pitch.js");
+      expect(
+        buildBackgroundImageUrlMap("d", [{ id: "s1", position: 0 }], []).size,
+      ).toBe(0);
+    });
+
+    it("ignores assets whose kind is not background", async () => {
+      const { buildBackgroundImageUrlMap } = await import("./pitch.js");
+      const map = buildBackgroundImageUrlMap(
+        "d",
+        [{ id: "s1", position: 0 }],
+        [
+          {
+            id: "a1",
+            slide_id: "s1",
+            kind: "image",
+            created_at: "2026-04-25T00:00:00Z",
+          },
+        ],
+      );
+      expect(map.size).toBe(0);
+    });
+
+    it("ignores assets whose slide_id is null or unknown", async () => {
+      const { buildBackgroundImageUrlMap } = await import("./pitch.js");
+      const map = buildBackgroundImageUrlMap(
+        "d",
+        [{ id: "s1", position: 0 }],
+        [
+          {
+            id: "a1",
+            slide_id: null,
+            kind: "background",
+            created_at: "2026-04-25T00:00:00Z",
+          },
+          {
+            id: "a2",
+            slide_id: "s-unknown",
+            kind: "background",
+            created_at: "2026-04-25T00:00:00Z",
+          },
+        ],
+      );
+      expect(map.size).toBe(0);
+    });
+
+    it("picks the latest background per slide and keys by position", async () => {
+      const { buildBackgroundImageUrlMap } = await import("./pitch.js");
+      const map = buildBackgroundImageUrlMap(
+        "deck-7",
+        [
+          { id: "s-alpha", position: 0 },
+          { id: "s-beta", position: 1 },
+        ],
+        [
+          {
+            id: "a-old",
+            slide_id: "s-alpha",
+            kind: "background",
+            created_at: "2026-04-01T00:00:00Z",
+          },
+          {
+            id: "a-new",
+            slide_id: "s-alpha",
+            kind: "background",
+            created_at: "2026-04-25T00:00:00Z",
+          },
+          {
+            id: "a-beta",
+            slide_id: "s-beta",
+            kind: "background",
+            created_at: "2026-04-10T00:00:00Z",
+          },
+        ],
+      );
+      expect(map.get(0)).toBe(
+        "/api/admin/pitch/decks/deck-7/assets/a-new",
+      );
+      expect(map.get(1)).toBe(
+        "/api/admin/pitch/decks/deck-7/assets/a-beta",
+      );
+    });
+
+    it("URL-encodes the deck and asset ids", async () => {
+      const { buildBackgroundImageUrlMap } = await import("./pitch.js");
+      const map = buildBackgroundImageUrlMap(
+        "deck/with space",
+        [{ id: "slide?", position: 0 }],
+        [
+          {
+            id: "a&special",
+            slide_id: "slide?",
+            kind: "background",
+            created_at: "2026-04-25T00:00:00Z",
+          },
+        ],
+      );
+      expect(map.get(0)).toBe(
+        "/api/admin/pitch/decks/deck%2Fwith%20space/assets/a%26special",
+      );
     });
   });
 });

--- a/src/api/pitch.ts
+++ b/src/api/pitch.ts
@@ -24,7 +24,7 @@
 import { mkdir, rename, stat, unlink, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
-import { extname, join, resolve } from "node:path";
+import { extname, join, relative, resolve } from "node:path";
 import { Router, type Request, type Response } from "express";
 import express from "express";
 import multer from "multer";
@@ -85,6 +85,13 @@ export interface PitchRouterDeps {
   characterRepo?: CharacterRepository;
   /** Override for the brand-kit asset directory (tests). Defaults to `~/.openzigs/brand-kits`. */
   brandKitsDir?: string;
+  /**
+   * Override for the pitch slide-asset directory (tests). Defaults to
+   * `~/.openzigs/pitch/assets` — must match `pitch-image-service.ts`
+   * because the asset-serve route below containment-checks against it
+   * (sub-issue #992).
+   */
+  assetsBaseDir?: string;
   /** Audit log sink. Mutating routes emit categorized events through it. */
   auditLogger?: AuditLogger;
   /** Socket.IO server. Mutating routes broadcast `pitch:*` events through it. */
@@ -104,6 +111,7 @@ export interface PitchRouterDeps {
 }
 
 const DEFAULT_BRAND_KITS_DIR = join(homedir(), ".openzigs", "brand-kits");
+const DEFAULT_ASSETS_DIR = join(homedir(), ".openzigs", "pitch", "assets");
 const STARTER_KIT_IDS = new Set(STARTER_BRAND_KITS.map((k) => k.id));
 const LOGO_MAX_BYTES = 2 * 1024 * 1024; // 2 MB cap (#966)
 // Allow-list per #966 acceptance criteria. SVG is intentionally excluded:
@@ -209,6 +217,55 @@ function toFileUrl(p: string): string {
   // Naive cross-platform file:// builder (sufficient for our local cache).
   const norm = p.replace(/\\/g, "/");
   return norm.startsWith("/") ? `file://${norm}` : `file:///${norm}`;
+}
+
+/**
+ * Sub-issue #992 — build a slide-index → background-asset URL map for
+ * the renderer. Picks the most-recently-created `kind="background"`
+ * asset per slide so re-generations win. The renderer keys by index
+ * (Deck JSON has no per-slide row IDs — see `assembleDeck` in
+ * `pitch-repository.ts`), so we resolve `asset.slide_id` →
+ * `slideRecord.position` here. URLs are root-relative paths into this
+ * router; the renderer re-validates them through `safeUrl` before
+ * emission.
+ */
+export function buildBackgroundImageUrlMap(
+  deckId: string,
+  slides: ReadonlyArray<{ id: string; position: number }>,
+  assets: ReadonlyArray<{
+    id: string;
+    slide_id: string | null;
+    kind: string;
+    created_at: string;
+  }>,
+): Map<number, string> {
+  const positionBySlideId = new Map<string, number>();
+  for (const s of slides) positionBySlideId.set(s.id, s.position);
+  const latestByPosition = new Map<
+    number,
+    { id: string; created_at: string }
+  >();
+  for (const asset of assets) {
+    if (asset.kind !== "background") continue;
+    if (!asset.slide_id) continue;
+    const position = positionBySlideId.get(asset.slide_id);
+    if (position === undefined) continue;
+    const prior = latestByPosition.get(position);
+    if (!prior || asset.created_at > prior.created_at) {
+      latestByPosition.set(position, {
+        id: asset.id,
+        created_at: asset.created_at,
+      });
+    }
+  }
+  const out = new Map<number, string>();
+  for (const [position, asset] of latestByPosition) {
+    out.set(
+      position,
+      `/api/admin/pitch/decks/${encodeURIComponent(deckId)}/assets/${encodeURIComponent(asset.id)}`,
+    );
+  }
+  return out;
 }
 
 // ── Body schemas ────────────────────────────────────────────────────────
@@ -363,6 +420,7 @@ function buildPlaceholderTitleSlide(title: string): Slide {
 export function createPitchRouter(deps: PitchRouterDeps): Router {
   const router = Router();
   const brandKitsDir = deps.brandKitsDir ?? DEFAULT_BRAND_KITS_DIR;
+  const assetsBaseDir = resolve(deps.assetsBaseDir ?? DEFAULT_ASSETS_DIR);
 
   // ── Audit + Socket.IO emit helpers ─────────────────────────────────
   // Both sinks are optional so test harnesses can opt-in. Production
@@ -524,6 +582,62 @@ export function createPitchRouter(deps: PitchRouterDeps): Router {
     res.json({ deck, slides });
   });
 
+  // ────────────────────────────────────────────────────────────────────
+  // Sub-issue #992 — Asset-serve endpoint
+  //
+  // Serves bytes for a `pitch_assets` row (typically a flux-generated
+  // background or inline image). Used by:
+  //   - the `/render` background URL map (this PR)
+  //   - future client-side previews (e.g. the regenerate dialog
+  //     thumbnail)
+  //
+  // Hardening:
+  //   - Asset must belong to the URL's deck (404 otherwise — no leakage
+  //     of which assetIds exist across decks).
+  //   - The resolved `local_path` must lie under `assetsBaseDir`. We
+  //     never trust the row blindly; defense-in-depth against any future
+  //     code path that might write a path traversal into the table.
+  //   - `Cache-Control: no-store` so a regenerated asset isn't served
+  //     stale.
+  // ────────────────────────────────────────────────────────────────────
+  router.get("/decks/:deckId/assets/:assetId", crudLimiter, (req, res) => {
+    const { deckId, assetId } = req.params;
+    const assets = deps.pitchRepo.listAssetsForDeck(deckId);
+    const asset = assets.find((a) => a.id === assetId);
+    if (!asset) {
+      sendError(res, 404, "not_found", "asset not found");
+      return;
+    }
+    // `listAssetsForDeck` already scopes to deckId, but be explicit.
+    if (asset.deck_id !== deckId) {
+      sendError(res, 404, "not_found", "asset not found");
+      return;
+    }
+    const absPath = resolve(asset.local_path);
+    const rel = relative(assetsBaseDir, absPath);
+    if (rel.startsWith("..") || resolve(assetsBaseDir, rel) !== absPath) {
+      audit(
+        "security",
+        "pitch_asset_path_outside_root",
+        { deckId, assetId, absPath, assetsBaseDir },
+        "warn",
+      );
+      sendError(res, 404, "not_found", "asset not found");
+      return;
+    }
+    if (!existsSync(absPath)) {
+      sendError(res, 404, "not_found", "asset file missing");
+      return;
+    }
+    res.setHeader("Content-Type", asset.mime || "application/octet-stream");
+    res.setHeader("Cache-Control", "no-store");
+    res.sendFile(absPath, (err) => {
+      if (err && !res.headersSent) {
+        sendError(res, 500, "internal_error", "asset send failed");
+      }
+    });
+  });
+
   // Phase 4 / sub-issue #963 — Reveal HTML render endpoint.
   router.get("/decks/:deckId/render", htmlLimiter, (req, res) => {
     const mode = req.query.mode === "standalone" ? "standalone" : "embedded";
@@ -544,7 +658,14 @@ export function createPitchRouter(deps: PitchRouterDeps): Router {
     }
     try {
       const brandKit = repoToPitchBrandKit(repoKit);
-      const { html, slideCount } = renderDeckToHtml(deck, brandKit, mode);
+      const backgroundImageUrlBySlideIndex = buildBackgroundImageUrlMap(
+        deck.id,
+        deps.pitchRepo.listSlidesForDeck(deck.id),
+        deps.pitchRepo.listAssetsForDeck(deck.id),
+      );
+      const { html, slideCount } = renderDeckToHtml(deck, brandKit, mode, {
+        backgroundImageUrlBySlideIndex,
+      });
       audit("system", "pitch_deck_rendered", {
         deckId: deck.id,
         mode,
@@ -664,10 +785,16 @@ export function createPitchRouter(deps: PitchRouterDeps): Router {
     const ctx = loadDeckAndKit(req, res);
     if (!ctx?.deck) return;
     try {
+      const backgroundImageUrlBySlideIndex = buildBackgroundImageUrlMap(
+        ctx.deck.id,
+        deps.pitchRepo.listSlidesForDeck(ctx.deck.id),
+        deps.pitchRepo.listAssetsForDeck(ctx.deck.id),
+      );
       const { html, slideCount } = renderDeckToHtml(
         ctx.deck,
         ctx.brandKit,
         "standalone",
+        { backgroundImageUrlBySlideIndex },
       );
       audit("system", "pitch_deck_exported", {
         deckId: ctx.deck.id,

--- a/src/pitch/pitch-renderer.test.ts
+++ b/src/pitch/pitch-renderer.test.ts
@@ -565,3 +565,83 @@ describe("renderDeckToHtml — per-template XSS hardening", () => {
     },
   );
 });
+
+// ────────────────────────────────────────────────────────────────────────
+// Sub-issue #992 — per-slide background image map
+// ────────────────────────────────────────────────────────────────────────
+describe("renderDeckToHtml — backgroundImageUrlBySlideIndex (#992)", () => {
+  const titleSlide = (): Slide =>
+    s("title", { title: "Hello", subtitle: "Sub" });
+  const bulletSlide = (): Slide =>
+    s("bullet_list", { heading: "H", bullets: ["a"] });
+
+  it("emits data-background-image on the matching <section> when a safe URL is supplied", () => {
+    const deck = buildDeck([titleSlide(), bulletSlide()]);
+    const map = new Map<number, string>([
+      [0, "/api/admin/pitch/decks/d/assets/a1"],
+    ]);
+    const html = renderDeckToHtml(deck, KIT, "embedded", {
+      backgroundImageUrlBySlideIndex: map,
+    }).html;
+    expect(html).toContain(
+      'data-background-image="/api/admin/pitch/decks/d/assets/a1"',
+    );
+    expect(html).toContain('data-background-size="cover"');
+    expect(html).toContain('data-background-position="center"');
+  });
+
+  it("does NOT emit data-background-image when the option is omitted (backwards compat)", () => {
+    const deck = buildDeck([titleSlide()]);
+    const html = renderDeckToHtml(deck, KIT, "embedded").html;
+    expect(html).not.toContain("data-background-image");
+  });
+
+  it("does NOT emit data-background-image when the slide index is not in the map", () => {
+    const deck = buildDeck([titleSlide(), bulletSlide()]);
+    const map = new Map<number, string>([
+      [1, "/api/admin/pitch/decks/d/assets/a-second-only"],
+    ]);
+    const html = renderDeckToHtml(deck, KIT, "embedded", {
+      backgroundImageUrlBySlideIndex: map,
+    }).html;
+    // Only the second slide gets the attribute.
+    const matches = html.match(/data-background-image="[^"]*"/g) ?? [];
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toContain("a-second-only");
+  });
+
+  it("silently drops a `javascript:` URL", () => {
+    const deck = buildDeck([titleSlide()]);
+    const map = new Map<number, string>([[0, "javascript:alert(1)"]]);
+    const html = renderDeckToHtml(deck, KIT, "embedded", {
+      backgroundImageUrlBySlideIndex: map,
+    }).html;
+    expect(html).not.toContain("javascript:");
+    expect(html).not.toContain("data-background-image");
+  });
+
+  it("silently drops a `data:` URL", () => {
+    const deck = buildDeck([titleSlide()]);
+    const map = new Map<number, string>([
+      [0, "data:image/png;base64,xxxx"],
+    ]);
+    const html = renderDeckToHtml(deck, KIT, "embedded", {
+      backgroundImageUrlBySlideIndex: map,
+    }).html;
+    expect(html).not.toContain("data-background-image");
+  });
+
+  it("works for non-title templates too", () => {
+    const deck = buildDeck([bulletSlide()]);
+    const map = new Map<number, string>([
+      [0, "https://cdn.example.com/x.png"],
+    ]);
+    const html = renderDeckToHtml(deck, KIT, "embedded", {
+      backgroundImageUrlBySlideIndex: map,
+    }).html;
+    expect(html).toContain(
+      'data-background-image="https://cdn.example.com/x.png"',
+    );
+  });
+});
+

--- a/src/pitch/pitch-renderer.ts
+++ b/src/pitch/pitch-renderer.ts
@@ -41,6 +41,21 @@ export interface RenderOpts {
   theme?: string;
   /** Standalone mode only — set to `false` to skip the inline init script. */
   autoInit?: boolean;
+  /**
+   * Per-slide background-image URLs to emit as Reveal.js
+   * `data-background-image` attributes on the `<section>` (sub-issue #992).
+   *
+   * Keyed by slide index (the Deck JSON does not carry per-slide row
+   * IDs — see `assembleDeck` in `pitch-repository.ts`). The caller
+   * (route handlers in `src/api/pitch.ts`) joins the `pitch_slides`
+   * table to the `pitch_assets` rows to produce the position→URL map.
+   * When omitted or empty the renderer behaves exactly as before — pure
+   * additive change.
+   *
+   * Each URL is re-validated through `safeUrl` here so an unsafe value
+   * (e.g. `javascript:`) is silently dropped rather than emitted.
+   */
+  backgroundImageUrlBySlideIndex?: ReadonlyMap<number, string>;
 }
 
 export interface RenderResult {
@@ -63,7 +78,10 @@ export function renderDeckToHtml(
   mode: RenderMode = "embedded",
   opts: RenderOpts = {},
 ): RenderResult {
-  const slidesHtml = deck.slides.map((slide) => renderSlide(slide)).join("\n");
+  const bgMap = opts.backgroundImageUrlBySlideIndex;
+  const slidesHtml = deck.slides
+    .map((slide, index) => renderSlide(slide, bgMap?.get(index)))
+    .join("\n");
   const wrapperStyle = brandKitInlineStyle(brandKit);
   const footer = brandKit.footerText
     ? `<footer class="pitch-footer">${sanitize(brandKit.footerText)}</footer>`
@@ -157,8 +175,8 @@ function standaloneStyles(): string {
 
 // ── Per-template renderers ─────────────────────────────────────────────
 
-function renderSlide(slide: Slide): string {
-  const sectionAttrs = sectionAttributes(slide);
+function renderSlide(slide: Slide, backgroundUrl?: string): string {
+  const sectionAttrs = sectionAttributes(slide, backgroundUrl);
   const body = renderTemplateBody(slide);
   const notes = slide.speaker_notes
     ? `<aside class="notes">${sanitize(slide.speaker_notes)}</aside>`
@@ -166,14 +184,24 @@ function renderSlide(slide: Slide): string {
   return `<section ${sectionAttrs}>${body}${notes}</section>`;
 }
 
-function sectionAttributes(slide: Slide): string {
+function sectionAttributes(slide: Slide, backgroundUrl?: string): string {
   const parts: string[] = [`data-template="${attr(slide.template)}"`];
   if (slide.transition && slide.transition !== "slide") {
     parts.push(`data-transition="${attr(slide.transition)}"`);
   }
-  // background_image_url is intentionally NOT honored here — the schema only
-  // carries `background_image_prompt` until the image service fills in a
-  // sanitized URL on a separate field elsewhere.
+  // Sub-issue #992 — background image URL is supplied by the caller (looked
+  // up from `pitch_assets` kind=background). Re-validate through `safeUrl`
+  // so a tampered URL never reaches the rendered HTML. When the URL is
+  // missing, malformed, or `safeUrl`-rejected, the section is emitted
+  // without the attribute and Reveal.js falls back to the theme background.
+  if (backgroundUrl) {
+    const safe = safeUrl(backgroundUrl);
+    if (safe) {
+      parts.push(`data-background-image="${attr(safe)}"`);
+      parts.push(`data-background-size="cover"`);
+      parts.push(`data-background-position="center"`);
+    }
+  }
   return parts.join(" ");
 }
 

--- a/ui/components/pitch/regenerate-image-dialog.test.tsx
+++ b/ui/components/pitch/regenerate-image-dialog.test.tsx
@@ -243,4 +243,110 @@ describe("RegenerateImageDialog", () => {
     fireEvent.change(ta, { target: { value: "a brand new prompt" } });
     expect(ta.value).toBe("a brand new prompt");
   });
+
+  // Sub-issue #992 — current-image preview prop
+  describe("currentImageUrl preview (#992)", () => {
+    it("renders thumbnail and 'Replace?' label when a safe URL is supplied", () => {
+      vi.mocked(fetchJson).mockResolvedValue({ characters: [] });
+      render(
+        <RegenerateImageDialog
+          open
+          onOpenChange={vi.fn()}
+          deckId="d"
+          slideId="s"
+          initialPrompt="prompt here"
+          mode="background"
+          currentImageUrl="/api/admin/pitch/decks/d/assets/a1"
+        />,
+        { wrapper },
+      );
+      const wrap = screen.getByTestId("pitch-regen-image-current");
+      expect(wrap).toBeInTheDocument();
+      expect(wrap).toHaveTextContent("Replace?");
+      const thumb = screen.getByTestId(
+        "pitch-regen-image-current-thumb",
+      ) as HTMLImageElement;
+      expect(thumb.getAttribute("src")).toBe(
+        "/api/admin/pitch/decks/d/assets/a1",
+      );
+    });
+
+    it("does not render the thumbnail when currentImageUrl is omitted", () => {
+      vi.mocked(fetchJson).mockResolvedValue({ characters: [] });
+      render(
+        <RegenerateImageDialog
+          open
+          onOpenChange={vi.fn()}
+          deckId="d"
+          slideId="s"
+          initialPrompt="prompt here"
+          mode="background"
+        />,
+        { wrapper },
+      );
+      expect(
+        screen.queryByTestId("pitch-regen-image-current"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("silently drops a thumbnail with an unsafe URL scheme", () => {
+      vi.mocked(fetchJson).mockResolvedValue({ characters: [] });
+      render(
+        <RegenerateImageDialog
+          open
+          onOpenChange={vi.fn()}
+          deckId="d"
+          slideId="s"
+          initialPrompt="prompt here"
+          mode="background"
+          currentImageUrl="javascript:alert(1)"
+        />,
+        { wrapper },
+      );
+      expect(
+        screen.queryByTestId("pitch-regen-image-current"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("accepts an https URL", () => {
+      vi.mocked(fetchJson).mockResolvedValue({ characters: [] });
+      render(
+        <RegenerateImageDialog
+          open
+          onOpenChange={vi.fn()}
+          deckId="d"
+          slideId="s"
+          initialPrompt="prompt here"
+          mode="background"
+          currentImageUrl="https://cdn.example.com/x.png"
+        />,
+        { wrapper },
+      );
+      const thumb = screen.getByTestId(
+        "pitch-regen-image-current-thumb",
+      ) as HTMLImageElement;
+      expect(thumb.getAttribute("src")).toBe(
+        "https://cdn.example.com/x.png",
+      );
+    });
+
+    it("treats whitespace-only URL as missing", () => {
+      vi.mocked(fetchJson).mockResolvedValue({ characters: [] });
+      render(
+        <RegenerateImageDialog
+          open
+          onOpenChange={vi.fn()}
+          deckId="d"
+          slideId="s"
+          initialPrompt="prompt here"
+          mode="background"
+          currentImageUrl="   "
+        />,
+        { wrapper },
+      );
+      expect(
+        screen.queryByTestId("pitch-regen-image-current"),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/ui/components/pitch/regenerate-image-dialog.tsx
+++ b/ui/components/pitch/regenerate-image-dialog.tsx
@@ -44,7 +44,30 @@ export interface RegenerateImageDialogProps {
   initialPrompt: string;
   /** "background" for full-bleed/title, "inline" for image_caption etc. */
   mode: "background" | "inline";
+  /**
+   * Sub-issue #992 — when set, render a small thumbnail of the current
+   * image with a "Replace?" caption above the prompt. Caller is
+   * responsible for supplying a safe URL (root-relative path or http(s)).
+   * `javascript:` / `data:` etc. are silently dropped client-side as
+   * defense-in-depth on top of the server-side `safeUrl` check.
+   */
+  currentImageUrl?: string;
   onQueued?: (jobId: string, assetId: string) => void;
+}
+
+/**
+ * Strict client-side URL allowlist for the thumbnail preview — mirrors
+ * `safeUrl` in `src/pitch/pitch-sanitize.ts`. Allows root-relative paths
+ * and `http(s)://`; everything else is rejected and the thumbnail is
+ * suppressed.
+ */
+function safePreviewUrl(input: string | undefined): string | null {
+  if (!input) return null;
+  const v = input.trim();
+  if (!v) return null;
+  if (v.startsWith("/")) return v;
+  if (/^https?:\/\//i.test(v)) return v;
+  return null;
 }
 
 export const RegenerateImageDialog = ({
@@ -54,6 +77,7 @@ export const RegenerateImageDialog = ({
   slideId,
   initialPrompt,
   mode,
+  currentImageUrl,
   onQueued,
 }: RegenerateImageDialogProps) => {
   const [prompt, setPrompt] = useState(initialPrompt);
@@ -128,6 +152,23 @@ export const RegenerateImageDialog = ({
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-3 text-xs">
+          {(() => {
+            const previewUrl = safePreviewUrl(currentImageUrl);
+            if (!previewUrl) return null;
+            return (
+              <div data-testid="pitch-regen-image-current">
+                <span className="mb-1 block font-semibold">
+                  Replace?
+                </span>
+                <img
+                  src={previewUrl}
+                  alt="Current image"
+                  data-testid="pitch-regen-image-current-thumb"
+                  className="max-h-32 w-auto rounded border border-border"
+                />
+              </div>
+            );
+          })()}
           <label className="block">
             <span className="mb-1 block font-semibold">Prompt</span>
             <textarea


### PR DESCRIPTION
Closes #992

Wires the missing path so a flux-generated background asset actually appears in the rendered Reveal.js deck and in the regenerate dialog. Single PR, single commit, single concern — no scope creep into #991/#993/#994.

## What changed

### Renderer (`src/pitch/pitch-renderer.ts`)
- New optional `backgroundImageUrlBySlideIndex: ReadonlyMap<number, string>` on `RenderOpts`.
- When present, the slide's `<section>` emits `data-background-image="…"` (re-validated through `safeUrl` so `javascript:` / `data:` are silently dropped) plus `data-background-size="cover"` and `data-background-position="center"`.
- Keyed by slide **index**, not row id, because `Deck.slides` doesn't carry per-slide IDs (see `assembleDeck` in `pitch-repository.ts`).
- Fully backwards-compatible: omitting the option produces byte-identical output to before.

### API (`src/api/pitch.ts`)
- New exported pure helper `buildBackgroundImageUrlMap(deckId, slides, assets)` that picks the latest `kind="background"` asset per slide (by `created_at`) and resolves `asset.slide_id → slideRecord.position`.
- Both `/decks/:deckId/render` and `/decks/:deckId/export.html` now compute the map and pass it through.
- New endpoint `GET /api/admin/pitch/decks/:deckId/assets/:assetId` that streams asset bytes from disk. Hardened:
  - Cross-deck guard — 404 if `asset.deck_id` ≠ URL deck id (no cross-deck enumeration).
  - Path-traversal guard — resolved `local_path` must lie under `assetsBaseDir` (defense-in-depth in case a future code path writes a malicious path into the table). Audit log on escape attempt (`category: security`, event: `pitch_asset_path_outside_root`).
  - Missing-file guard — 404 instead of 500.
  - `Cache-Control: no-store` so a regenerated asset is never stale.
  - Rate-limited via the existing `crudLimiter` and auth-gated through the `/api/admin/pitch` mount-point.
- `PitchRouterDeps` gains an optional `assetsBaseDir` field (defaults to `~/.openzigs/pitch/assets`, matching the canonical write path in `pitch-image-service.ts`).

### UI (`ui/components/pitch/regenerate-image-dialog.tsx`)
- New optional `currentImageUrl` prop. When supplied (and the URL passes a strict client-side allowlist mirroring server-side `safeUrl`), the dialog renders a small thumbnail with a "Replace?" caption above the prompt textarea.
- Preview safely no-ops on `javascript:` / `data:` / whitespace.

## Acceptance criteria

- [x] **#992 AC #1** — Renderer can emit a per-slide background image attribute when an asset exists.
- [x] **#992 AC #2** — `/render` endpoint computes the map from `pitch_assets` and passes it to the renderer.
- [x] **#992 AC #3** — Asset bytes are reachable from the browser via a URL that is auth-gated, rate-limited, and path-traversal-safe.
- [x] **#992 AC #4** — Regenerate dialog can show "what you're replacing" UI when given a current URL.

### Known follow-up (deliberately out of scope)
- `ui/components/pitch/property-editors/title.tsx` does **not** yet pass `currentImageUrl` to the dialog — the slide schema doesn't carry the URL, so the editor needs a small React Query lookup against the asset list. The dialog UI + URL-safety logic + tests are in place; wiring real data is a tiny follow-up PR (no API or renderer change required).

## Test coverage

| Area | New tests | File coverage (statements) |
|------|-----------|----------------------------|
| Renderer (#992 background plumbing) | +6 | **98.26%** |
| Pitch API (asset-serve route + helper) | +12 | **93.7%** |
| Regenerate dialog (`currentImageUrl` prop) | +5 | already at high coverage |

All other tests untouched.

## Quality gate

| Gate | Result |
|------|--------|
| `pnpm lint` | ✅ PASS |
| `pnpm typecheck` | ✅ PASS |
| `pnpm test` | ✅ PASS — 7014/7014 |
| `cd ui && npx next build` | ✅ PASS — 40/40 static pages |

## Security notes

- URL written into `data-background-image` is re-validated through `safeUrl` inside the renderer — never trusts the caller.
- Asset endpoint enforces deck ownership AND a `path.relative()` containment check against `assetsBaseDir`. Both checks are necessary because the DB and the FS are separate trust domains.
- Rate-limited (`crudLimiter` = 600/min/IP) and auth-gated through the mount point — same posture as every other pitch route.
- Client-side URL allowlist in the dialog mirrors the server allowlist — XSS-safe even if a future caller passes an attacker-controlled URL.
- No new dependencies. No new secrets. No CodeQL findings expected.