### PR TITLE
docs(graphify): wire codebase knowledge graph into orchestrator + skills (#1026)

### DIFF
--- a/.github/agents/orchestrator.agent.md
+++ b/.github/agents/orchestrator.agent.md
@@ -34,6 +34,17 @@ You are a **Software Development Orchestrator**. Your purpose is to drive an end
 
 By running the entire Plan → Implement → Review pipeline in a single session through subagent calls, we minimize premium request consumption. Each `#tool:agent/runSubagent` call runs the specialized agent within this session rather than creating a new one.
 
+## Token Reduction with graphify (codebase knowledge graph)
+
+This repo opts into [graphify](https://github.com/safishamsi/graphify), a Python CLI that builds a precomputed knowledge graph of the codebase. **Before delegating to any subagent that will read or grep the repo (Code Planner, Code Issue, Code Review, Research)**, check whether `graphify-out/GRAPH_REPORT.md` and `graphify-out/graph.json` exist at the workspace root.
+
+- **If present**: include this line verbatim in every subagent prompt that follows:
+  > *"Before broad file searches, read [graphify-out/GRAPH_REPORT.md](graphify-out/GRAPH_REPORT.md) for the codebase overview, and prefer `graphify query "<terms>" graphify-out/graph.json` (or `graphify path <fileA> <fileB>` for impact analysis) over wide grep/file_search sweeps. The graph is the cheapest way to navigate the repo."*
+- **If stale** (older than the most recent commit on the working branch): mention in the same line that the graph may be slightly out-of-date and the subagent should fall back to grep for files modified after the graph was built.
+- **If missing**: do nothing extra. graphify is opt-in; never block the workflow on it. The install/build instructions live in [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+Do not invoke `graphify` yourself. The CLI is owned by the developer; it is built/refreshed locally via `graphify .` (or via the post-commit hook installed by `graphify hook install`). Your job is only to *point subagents at the artefact when it exists*.
+
 ## Workflow (#tool:todo)
 
 Track progress through these phases using `#tool:todo`:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,9 @@
 # Copilot Instructions (openzigs)
 
+## Codebase navigation hint (graphify)
+
+If [graphify-out/GRAPH_REPORT.md](graphify-out/GRAPH_REPORT.md) exists at the repo root, **read it before any wide grep or file_search sweep** — it is a precomputed knowledge graph of the codebase and dramatically reduces tokens for "where is X defined / used" questions. For deeper queries, run `graphify query "<terms>" graphify-out/graph.json` (token-bounded subgraph) or `graphify path <fileA> <fileB>` (dependency reach). The graph is opt-in dev tooling — if `graphify-out/` is missing, fall through to normal search. Install/build instructions: see [CONTRIBUTING.md](../CONTRIBUTING.md#optional-graphify-knowledge-graph).
+
 ## Architecture Overview
 - **Express server** ([src/server.ts](src/server.ts)) bootstraps all subsystems: config, tools, sessions, tasks, scheduler, personality, Sentinel, channels, Socket.IO wiring.
 - **AI wrapper** ([src/copilot/copilot-wrapper.ts](src/copilot/copilot-wrapper.ts)): wraps `@github/copilot-sdk` for device auth, streaming chat, tool-call hooks, and session-level token tracking.

--- a/.github/skills/code-issue/SKILL.md
+++ b/.github/skills/code-issue/SKILL.md
@@ -61,8 +61,9 @@ This skill should be executed by the **Code Issue** agent (`code-issue.agent.md`
 2. If it has sub-issues, read each one to understand full scope
 3. Use `mcp_context7_resolve-library-id` + `mcp_context7_query-docs` for any library questions
 4. Use `fetch_webpage` to pull reference documentation or examples
-5. Analyze the codebase — identify affected files, patterns, and conventions
-6. Create a task tracking list with all issues to resolve
+5. **Consult the graphify knowledge graph first.** If `graphify-out/GRAPH_REPORT.md` exists at the repo root, read it before any wide grep/file_search sweep — it is a precomputed summary of the entire codebase and saves tokens. Then use `graphify query "<terms>" graphify-out/graph.json` to get a token-bounded subgraph for the area you'll touch (function/class/file dependencies, imports, callers). Use `graphify path <fileA> <fileB>` to understand reach when changing shared modules. Fall back to grep only for files modified after the graph was built (check `graphify-out/manifest.json` mtime vs. `git log -1 --format=%ct -- <file>`).
+6. Analyze the codebase — identify affected files, patterns, and conventions
+7. Create a task tracking list with all issues to resolve
 
 ### Step 2: Branch Setup
 

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -81,6 +81,7 @@ Execute with the **Code Review** agent (`code-review.agent.md`), which has the s
    gh pr view {PR_NUMBER} --json files --jq '.files[].path'
    ```
 6. **Read each changed file in full** — not just the diff hunks. Context matters.
+7. **Impact analysis via graphify (if available).** If `graphify-out/graph.json` exists, run `graphify query "<symbol_or_path>" graphify-out/graph.json` for each significantly changed module and `graphify path <changed_file> <suspected_dependent>` to surface non-obvious callers/importers. Flag any caller in the PR description that the diff didn't update — these are common review-blocking regressions. Skip if no graph is present (it's opt-in dev tooling, not a hard requirement).
 
 ### Step 1b: Security Scanner Comments (CodeQL / GHAS)
 

--- a/.github/skills/epic-planner/SKILL.md
+++ b/.github/skills/epic-planner/SKILL.md
@@ -71,6 +71,9 @@ Determine the `owner/repo` for issue creation:
 2. Ask the user if not obvious: *"Which GitHub repository should I create these issues in?"*
 3. Verify repo exists using `mcp_github_issue_read` on issue #1 (or list issues)
 
+#### 0a.1 Codebase context via graphify (if available)
+If `graphify-out/GRAPH_REPORT.md` exists at the repo root, read it before drafting epics — it gives a token-cheap overview of the codebase structure that helps you scope sub-issues to the right modules. Run `graphify query "<feature_topic>" graphify-out/graph.json` to identify which existing files/symbols the new work will touch (informs sub-issue boundaries and acceptance criteria). Skip if no graph is present.
+
 #### 0b. Research Sources — Ask the User
 
 Present this prompt:

--- a/.github/skills/research-gather/SKILL.md
+++ b/.github/skills/research-gather/SKILL.md
@@ -27,6 +27,7 @@ This skill collects and converts research material from multiple sources into a 
 | `fetch_webpage` | Fetch a specific URL when Tavily is unavailable |
 | `mcp_context7_resolve-library-id` | Resolve library IDs |
 | `mcp_context7_query-docs` | Fetch framework/library documentation |
+| `graphify` (CLI) | Query the local codebase knowledge graph (`graphify-out/graph.json`) for code research questions — far cheaper than grepping when the question is "where is X used?" or "what depends on Y?". Skip if `graphify-out/` is absent. |
 
 ## Workflow
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,13 @@
 # Node
 node_modules/
 
+# graphify (codebase knowledge graph — opt-in dev tool)
+# Commit graph.json + GRAPH_REPORT.md + graph.html for team sharing.
+# Ignore the per-developer cache, manifest, and cost ledger.
+graphify-out/cache/
+graphify-out/manifest.json
+graphify-out/cost.json
+
 # Playwright
 test-results/
 playwright-report/

--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,0 +1,83 @@
+# .graphifyignore — exclude paths from the graphify codebase knowledge graph.
+# Syntax mirrors .gitignore. See https://github.com/safishamsi/graphify
+
+# Node / pnpm
+node_modules/
+.pnpm-store/
+
+# Next.js build outputs
+.next/
+ui/.next/
+out/
+
+# Build artefacts
+dist/
+build/
+*.tsbuildinfo
+
+# Test artefacts
+coverage/
+test-results/
+playwright-report/
+.playwright-mcp/
+ui/test-results/
+ui/playwright-report/
+
+# Vendored / external code (not authored here)
+external/
+patches/
+
+# Python sidecar virtualenvs and caches
+sidecars/**/.venv/
+sidecars/**/__pycache__/
+sidecars/**/*.pyc
+sidecars/**/models/
+sidecars/**/checkpoints/
+sidecars/**/weights/
+sidecars/**/*.safetensors
+sidecars/**/*.bin
+sidecars/**/*.ckpt
+sidecars/**/*.pt
+
+# Docker / container artefacts
+.docker/
+*.tar
+
+# Generated content / scratch files
+*.generated.*
+*.min.js
+*.min.css
+*.map
+
+# Local data and logs
+.openzigs/
+logs/
+*.log
+*.jsonl
+
+# Lock files (graph wouldn't gain useful structure)
+pnpm-lock.yaml
+package-lock.json
+yarn.lock
+
+# Graphify's own outputs (avoid recursive analysis)
+graphify-out/
+
+# IDE
+.vscode/
+.idea/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Repo scratch / one-off files
+_*.txt
+_*.ps1
+_*.md
+test-out.txt
+typecheck-out.txt
+lint-out.txt
+pinterest-snapshots-*.json
+pr-body-*.md
+smoke-*.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Dev tooling: graphify codebase-graph integration for Copilot subagents (Epic #1026).** The orchestrator agent (`.github/agents/orchestrator.agent.md`) and the `code-issue`, `code-review`, and `research-gather` skills now consult `graphify-out/GRAPH_REPORT.md` (when present) and use `graphify query` / `graphify path` for impact analysis instead of broad grep sweeps. Reduces premium-request token usage when coding on openzigs. Opt-in for developers — install via `pip install graphifyy` (Windows) or `uv tool install graphifyy` (Mac/Linux), then `graphify .` to build, `graphify hook install` to auto-refresh on commit. New `.graphifyignore` excludes `node_modules/`, `.next/`, `dist/`, `external/`, `coverage/`, sidecar venvs, and other generated content. `.gitignore` updated to ignore graphify cache/manifest while committing the shared `graph.json`, `GRAPH_REPORT.md`, and `graph.html`. See [CONTRIBUTING.md](CONTRIBUTING.md#optional-graphify-knowledge-graph) for setup. **No openzigs runtime changes** — graphify is purely a developer-side workflow optimization. (#1026)
+
 ### Added
 
 - **Playwright e2e coverage for Pitch Pro features (Epic #990).** New `ui/e2e/pitch-pro-epic-990.spec.ts` (12 tests) plus two Page Objects (`pitch-editor.page.ts`, `pitch-wizard.page.ts`) verify the user-facing acceptance criteria of sub-issues #991 (Generate-all-images toolbar button), #992/#999 (Present link), #993 (HTML export menu item + download), #994 (regenerate-image dialog flow + queued-status badge), #995 (title-slide background regenerate), #996 (real iframe thumbnails), #997 (polished Reveal.js embedded preview), and #998 (image style preset selector + draft-body wiring). All network is mocked via `page.route()` so the suite is hermetic — no backend, sidecars, or seeded brand kit required.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Thank you for your interest in contributing to OpenZigs! This document provides 
 - [Code of Conduct](#code-of-conduct)
 - [Getting Started](#getting-started)
 - [Development Setup](#development-setup)
+- [Optional: graphify knowledge graph](#optional-graphify-knowledge-graph)
 - [Branching Strategy](#branching-strategy)
 - [Changelog](#changelog)
 - [Pull Request Process](#pull-request-process)
@@ -62,6 +63,59 @@ Copy `.env.example` to `.env` and configure the required values:
 ```bash
 cp .env.example .env
 ```
+
+## Optional: graphify knowledge graph
+
+[graphify](https://github.com/safishamsi/graphify) is an opt-in developer tool that builds a precomputed knowledge graph of the codebase. When the graph exists at `graphify-out/`, our Copilot subagents (orchestrator, code-issue, code-review, research-gather) consult it before doing wide grep / file-search sweeps. This typically saves **a large amount of premium-request tokens** when working with the AI on this repo.
+
+**Install (one-time):**
+
+| Platform | Command |
+|----------|---------|
+| Mac / Linux (recommended) | `uv tool install graphifyy` |
+| Mac / Linux (alternative) | `pipx install graphifyy` |
+| Windows | `pip install graphifyy` (then ensure `%APPDATA%\Python\Python3X\Scripts` is on `PATH`) |
+
+Note the PyPI package name is `graphifyy` (double **y**); the CLI binary is `graphify`.
+
+**Build the graph (one-time, then refresh on demand):**
+
+```bash
+graphify .
+```
+
+This produces:
+- `graphify-out/graph.json` — the queryable graph (commit this; teammates benefit)
+- `graphify-out/GRAPH_REPORT.md` — human-readable codebase overview (commit this)
+- `graphify-out/graph.html` — interactive graph viewer (commit this)
+- `graphify-out/cache/`, `manifest.json`, `cost.json` — per-developer state (gitignored)
+
+**Auto-refresh on commit / branch switch (optional):**
+
+```bash
+graphify hook install
+```
+
+Installs `post-commit` and `post-checkout` git hooks that re-run `graphify .` so the graph never goes stale.
+
+**VS Code Copilot Chat first-class support:**
+
+```bash
+graphify vscode install
+```
+
+This writes a snippet into `.github/copilot-instructions.md` (already done in this repo) so VS Code Copilot Chat consults the graph automatically every session.
+
+**Query the graph manually** (useful when you're navigating unfamiliar code):
+
+```bash
+graphify query "task engine worker recursion" graphify-out/graph.json   # token-bounded subgraph for a topic
+graphify path src/server.ts src/api/admin.ts                           # show dependency reach between two files
+```
+
+**What is excluded from the graph:** see [.graphifyignore](.graphifyignore) at the repo root — it skips `node_modules/`, `.next/`, `dist/`, `external/`, sidecar Python venvs, generated files, and ML model checkpoints.
+
+**Privacy note:** code is parsed locally via tree-sitter (no API calls). Only documentation, papers, and images (none in this repo by default) would be sent to a model API. See the upstream [graphify README](https://github.com/safishamsi/graphify#privacy) for details.
 
 ## Branching Strategy
 


### PR DESCRIPTION
﻿## Summary

Integrates [graphify](https://github.com/safishamsi/graphify) as an **opt-in developer-side workflow tool** that lets our Copilot subagents (orchestrator, code-issue, code-review, research-gather) consult a precomputed codebase knowledge graph instead of doing wide grep / file-search sweeps. This typically reduces premium-request token usage when working with the AI on this repo.

### What changed (docs / config only — zero runtime code)

- `.github/agents/orchestrator.agent.md` — new `Token Reduction with graphify` section that instructs the orchestrator to point each delegated subagent at `graphify-out/GRAPH_REPORT.md` and to suggest `graphify query` / `graphify path` when the graph is present.
- `.github/skills/code-issue/SKILL.md` — Step 1 (Planning) now consults the graph before broad grep.
- `.github/skills/code-review/SKILL.md` — Step 1 (Orient) now uses `graphify path` for impact analysis to surface non-obvious callers.
- `.github/skills/research-gather/SKILL.md` — adds `graphify` CLI to the tool table.
- `.github/copilot-instructions.md` — top-level pointer (auto-loaded by VS Code Copilot Chat every session).
- `.graphifyignore` (new) — excludes `node_modules/`, `.next/`, `dist/`, `external/`, sidecar Python venvs, ML checkpoints, generated files, repo scratch files.
- `.gitignore` — ignores `graphify-out/cache/`, `manifest.json`, `cost.json` (per-developer state) but commits `graph.json`, `GRAPH_REPORT.md`, `graph.html` for team sharing.
- `CONTRIBUTING.md` — new `Optional: graphify knowledge graph` section with cross-platform install, build, hook setup, and privacy notes.
- `CHANGELOG.md` — entry under `[Unreleased] ### Changed`.

### Why not in-app?

graphify is owned by the developer (Python CLI), invoked locally, and integrates first-class with VS Code Copilot Chat via `graphify vscode install`. There is no benefit to wiring it into the openzigs server itself — it would just duplicate the CLI surface. An earlier attempt (Python bootstrap, MCP registration, REST routes, Socket.IO progress — originally tracked in #1027–#1032) has been backed out as out-of-scope; those sub-issues are closed as `not planned`.

### Quality Gate

- `pnpm typecheck` — ✅ (no TS changes)
- `pnpm lint` — ✅
- No new tests required (all changes are docs / agent / skill markdown)

Closes #1026.
